### PR TITLE
Fix rubocop violations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
   - rvm: 2.5.3
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 6.0" CHECK=test_with_coveralls
+  - rvm: 2.5.3
+    bundler_args: --without system_tests development release
+    env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -34,8 +34,8 @@ describe 'check_mk::agent::config', type: :class do
       let :params do
         {
             ip_whitelist: [
-                '1.2.3.4',
-                '5.6.7.8'
+              '1.2.3.4',
+              '5.6.7.8'
             ]
         }
       end

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -26,6 +26,7 @@ describe 'check_mk::agent::config', type: :class do
           use_cache: true
         }
       end
+
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_caching_agent$/)
       }
@@ -39,6 +40,7 @@ describe 'check_mk::agent::config', type: :class do
           ]
         }
       end
+
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$/)
       }
@@ -49,6 +51,7 @@ describe 'check_mk::agent::config', type: :class do
           user: 'custom'
         }
       end
+
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tuser\s+ = custom$/)
       }

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -23,7 +23,7 @@ describe 'check_mk::agent::config', type: :class do
     context 'with use_cache' do
       let :params do
         {
-            use_cache: true
+          use_cache: true
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
@@ -33,10 +33,10 @@ describe 'check_mk::agent::config', type: :class do
     context 'with ip_whitelist' do
       let :params do
         {
-            ip_whitelist: [
-              '1.2.3.4',
-              '5.6.7.8'
-            ]
+          ip_whitelist: [
+            '1.2.3.4',
+            '5.6.7.8'
+          ]
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
@@ -46,7 +46,7 @@ describe 'check_mk::agent::config', type: :class do
     context 'with custom user' do
       let :params do
         {
-            user: 'custom'
+          user: 'custom'
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -76,5 +76,3 @@ describe 'check_mk::agent::config', type: :class do
     end
   end
 end
-
-

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -14,7 +14,7 @@ describe 'check_mk::agent::config', type: :class do
         is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(%r{^\tport\s+ = 6556$}).
           with_content(%r{^\tuser\s+ = root$}).
-          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
+          with_content(%r{^\tserver\s+ = /usr/bin/check_mk_agent$}).
           without_content(%r{only_from}).
           with_notify('Class[Check_mk::Agent::Service]')
       }
@@ -29,7 +29,7 @@ describe 'check_mk::agent::config', type: :class do
 
       it {
         is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
-          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_caching_agent$/)
+          with_content(%r{^\tserver\s+ = /usr/bin/check_mk_caching_agent$})
       }
     end
     context 'with ip_whitelist' do
@@ -75,7 +75,7 @@ describe 'check_mk::agent::config', type: :class do
         is_expected.to contain_file('/etc/xinetd.d/check_mk').
           with_content(%r{^\tport\s+ = 6556$}).
           with_content(%r{^\tuser\s+ = root$}).
-          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
+          with_content(%r{^\tserver\s+ = /usr/bin/check_mk_agent$}).
           without_content(%r{only_from}).
           with_notify('Class[Check_mk::Agent::Service]')
       }

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -12,10 +12,10 @@ describe 'check_mk::agent::config', type: :class do
       it { is_expected.to contain_class('check_mk::agent::config') }
       it {
         is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
-          with_content(/^\tport\s+ = 6556$/).
-          with_content(/^\tuser\s+ = root$/).
+          with_content(%r{^\tport\s+ = 6556$}).
+          with_content(%r{^\tuser\s+ = root$}).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
-          without_content(/only_from/).
+          without_content(%r{only_from}).
           with_notify('Class[Check_mk::Agent::Service]')
       }
       it { is_expected.to contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
@@ -44,7 +44,7 @@ describe 'check_mk::agent::config', type: :class do
 
       it {
         is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
-          with_content(/^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$/)
+          with_content(%r{^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$})
       }
     end
     context 'with custom user' do
@@ -56,7 +56,7 @@ describe 'check_mk::agent::config', type: :class do
 
       it {
         is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
-          with_content(/^\tuser\s+ = custom$/)
+          with_content(%r{^\tuser\s+ = custom$})
       }
     end
   end
@@ -73,10 +73,10 @@ describe 'check_mk::agent::config', type: :class do
     context 'with defaults for all parameters' do
       it {
         is_expected.to contain_file('/etc/xinetd.d/check_mk').
-          with_content(/^\tport\s+ = 6556$/).
-          with_content(/^\tuser\s+ = root$/).
+          with_content(%r{^\tport\s+ = 6556$}).
+          with_content(%r{^\tuser\s+ = root$}).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
-          without_content(/only_from/).
+          without_content(%r{only_from}).
           with_notify('Class[Check_mk::Agent::Service]')
       }
       it { is_expected.not_to contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -10,15 +10,15 @@ describe 'check_mk::agent::config', type: :class do
     end
 
     context 'with defaults for all parameters' do
-      it { should contain_class('check_mk::agent::config') }
-      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+      it { is_expected.to contain_class('check_mk::agent::config') }
+      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tport\s+ = 6556$/).
           with_content(/^\tuser\s+ = root$/).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
           without_content(/only_from/).
           with_notify('Class[Check_mk::Agent::Service]')
       }
-      it { should contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
+      it { is_expected.to contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
     end
     context 'with use_cache' do
       let :params do
@@ -26,7 +26,7 @@ describe 'check_mk::agent::config', type: :class do
             use_cache: true,
         }
       end
-      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_caching_agent$/)
       }
     end
@@ -39,7 +39,7 @@ describe 'check_mk::agent::config', type: :class do
             ],
         }
       end
-      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$/)
       }
     end
@@ -49,7 +49,7 @@ describe 'check_mk::agent::config', type: :class do
             user: 'custom',
         }
       end
-      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tuser\s+ = custom$/)
       }
     end
@@ -65,14 +65,14 @@ describe 'check_mk::agent::config', type: :class do
     end
 
     context 'with defaults for all parameters' do
-      it { should contain_file('/etc/xinetd.d/check_mk').
+      it { is_expected.to contain_file('/etc/xinetd.d/check_mk').
           with_content(/^\tport\s+ = 6556$/).
           with_content(/^\tuser\s+ = root$/).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
           without_content(/only_from/).
           with_notify('Class[Check_mk::Agent::Service]')
       }
-      it { should_not contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
+      it { is_expected.not_to contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
     end
   end
 end

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -10,7 +10,8 @@ describe 'check_mk::agent::config', type: :class do
 
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('check_mk::agent::config') }
-      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
+      it {
+        is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tport\s+ = 6556$/).
           with_content(/^\tuser\s+ = root$/).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
@@ -26,7 +27,8 @@ describe 'check_mk::agent::config', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
+      it {
+        is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_caching_agent$/)
       }
     end
@@ -40,7 +42,8 @@ describe 'check_mk::agent::config', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
+      it {
+        is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$/)
       }
     end
@@ -51,7 +54,8 @@ describe 'check_mk::agent::config', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
+      it {
+        is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
           with_content(/^\tuser\s+ = custom$/)
       }
     end
@@ -67,7 +71,8 @@ describe 'check_mk::agent::config', type: :class do
     end
 
     context 'with defaults for all parameters' do
-      it { is_expected.to contain_file('/etc/xinetd.d/check_mk').
+      it {
+        is_expected.to contain_file('/etc/xinetd.d/check_mk').
           with_content(/^\tport\s+ = 6556$/).
           with_content(/^\tuser\s+ = root$/).
           with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -23,7 +23,7 @@ describe 'check_mk::agent::config', type: :class do
     context 'with use_cache' do
       let :params do
         {
-            use_cache: true,
+            use_cache: true
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
@@ -35,8 +35,8 @@ describe 'check_mk::agent::config', type: :class do
         {
             ip_whitelist: [
                 '1.2.3.4',
-                '5.6.7.8',
-            ],
+                '5.6.7.8'
+            ]
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').
@@ -46,7 +46,7 @@ describe 'check_mk::agent::config', type: :class do
     context 'with custom user' do
       let :params do
         {
-            user: 'custom',
+            user: 'custom'
         }
       end
       it { is_expected.to contain_file('/etc/xinetd.d/check-mk-agent').

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe 'check_mk::agent::config', :type => :class do
+describe 'check_mk::agent::config', type: :class do
 
   context 'Redhat Linux' do
     let :facts do
@@ -23,7 +23,7 @@ describe 'check_mk::agent::config', :type => :class do
     context 'with use_cache' do
       let :params do
         {
-            :use_cache => true,
+            use_cache: true,
         }
       end
       it { should contain_file('/etc/xinetd.d/check-mk-agent').
@@ -33,7 +33,7 @@ describe 'check_mk::agent::config', :type => :class do
     context 'with ip_whitelist' do
       let :params do
         {
-            :ip_whitelist => [
+            ip_whitelist: [
                 '1.2.3.4',
                 '5.6.7.8',
             ],
@@ -46,7 +46,7 @@ describe 'check_mk::agent::config', :type => :class do
     context 'with custom user' do
       let :params do
         {
-            :user => 'custom',
+            user: 'custom',
         }
       end
       it { should contain_file('/etc/xinetd.d/check-mk-agent').

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 describe 'check_mk::agent::config', type: :class do
-
   context 'Redhat Linux' do
     let :facts do
       {

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -14,7 +14,7 @@ describe 'check_mk::agent::install' do
               version: nil,
               filestore: nil,
               workspace: '/root/check_mk',
-              package: nil,
+              package: nil
             }
           )
           }
@@ -25,7 +25,7 @@ describe 'check_mk::agent::install' do
         context 'with custom package' do
           let :params do
             {
-              package: 'custom-package',
+              package: 'custom-package'
             }
           end
           it { is_expected.to contain_class('check_mk::agent::install') }
@@ -37,7 +37,7 @@ describe 'check_mk::agent::install' do
           context 'without version' do
             let :params do
               {
-                filestore: '/filestore',
+                filestore: '/filestore'
               }
             end
             it 'should fail' do
@@ -49,7 +49,7 @@ describe 'check_mk::agent::install' do
               {
                 version: '1.2.3',
                 filestore: '/filestore',
-                workspace: '/workspace',
+                workspace: '/workspace'
               }
             end
             it { is_expected.to contain_class('check_mk::agent::install') }
@@ -59,14 +59,14 @@ describe 'check_mk::agent::install' do
               {
                 ensure: 'present',
                 source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
-                require: 'Package[xinetd]',
+                require: 'Package[xinetd]'
               }
             ).that_comes_before('Package[check_mk-agent]')
             }
             it { is_expected.to contain_package('check_mk-agent').with(
               {
                 provider: 'rpm',
-                source: '/workspace/check_mk-agent-1.2.3.noarch.rpm',
+                source: '/workspace/check_mk-agent-1.2.3.noarch.rpm'
               }
             )
             }
@@ -82,7 +82,7 @@ describe 'check_mk::agent::install' do
         context 'with custom package' do
           let :params do
             {
-              package: 'custom-package',
+              package: 'custom-package'
             }
           end
           it { is_expected.to contain_class('check_mk::agent::install') }

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -28,6 +28,7 @@ describe 'check_mk::agent::install' do
               package: 'custom-package'
             }
           end
+
           it { is_expected.to contain_class('check_mk::agent::install') }
           it { is_expected.to contain_package('xinetd') }
           it { is_expected.to contain_package('check_mk-agent').with_name('custom-package') }
@@ -40,6 +41,7 @@ describe 'check_mk::agent::install' do
                 filestore: '/filestore'
               }
             end
+
             it 'should fail' do
               expect { catalogue }.to raise_error(Puppet::Error, /version must be specified/)
             end
@@ -52,6 +54,7 @@ describe 'check_mk::agent::install' do
                 workspace: '/workspace'
               }
             end
+
             it { is_expected.to contain_class('check_mk::agent::install') }
             it { is_expected.to contain_package('xinetd') }
             it { is_expected.to contain_file('/workspace').with_ensure('directory') }
@@ -85,6 +88,7 @@ describe 'check_mk::agent::install' do
               package: 'custom-package'
             }
           end
+
           it { is_expected.to contain_class('check_mk::agent::install') }
           it { is_expected.to contain_package('xinetd') }
           it { is_expected.to contain_package('check_mk-agent').with_name('custom-package') }

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -42,7 +42,7 @@ describe 'check_mk::agent::install' do
             end
 
             it 'fails' do
-              expect { catalogue }.to raise_error(Puppet::Error, /version must be specified/)
+              expect { catalogue }.to raise_error(Puppet::Error, %r{version must be specified})
             end
           end
           context 'with custom parameters' do

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -9,7 +9,7 @@ describe 'check_mk::agent::install' do
       case facts[:osfamily]
       when 'Redhat'
         context 'with default parameters' do
-          it { should contain_class('check_mk::agent::install').with(
+          it { is_expected.to contain_class('check_mk::agent::install').with(
             {
               version: nil,
               filestore: nil,
@@ -18,8 +18,8 @@ describe 'check_mk::agent::install' do
             }
           )
           }
-          it { should contain_package('xinetd') }
-          it { should contain_package('check_mk-agent').with_name('check-mk-agent') }
+          it { is_expected.to contain_package('xinetd') }
+          it { is_expected.to contain_package('check_mk-agent').with_name('check-mk-agent') }
         end
 
         context 'with custom package' do
@@ -28,9 +28,9 @@ describe 'check_mk::agent::install' do
               package: 'custom-package',
             }
           end
-          it { should contain_class('check_mk::agent::install') }
-          it { should contain_package('xinetd') }
-          it { should contain_package('check_mk-agent').with_name('custom-package') }
+          it { is_expected.to contain_class('check_mk::agent::install') }
+          it { is_expected.to contain_package('xinetd') }
+          it { is_expected.to contain_package('check_mk-agent').with_name('custom-package') }
         end
 
         context 'with filestore' do
@@ -52,10 +52,10 @@ describe 'check_mk::agent::install' do
                 workspace: '/workspace',
               }
             end
-            it { should contain_class('check_mk::agent::install') }
-            it { should contain_package('xinetd') }
-            it { should contain_file('/workspace').with_ensure('directory') }
-            it { should contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
+            it { is_expected.to contain_class('check_mk::agent::install') }
+            it { is_expected.to contain_package('xinetd') }
+            it { is_expected.to contain_file('/workspace').with_ensure('directory') }
+            it { is_expected.to contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
               {
                 ensure: 'present',
                 source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
@@ -63,7 +63,7 @@ describe 'check_mk::agent::install' do
               }
             ).that_comes_before('Package[check_mk-agent]')
             }
-            it { should contain_package('check_mk-agent').with(
+            it { is_expected.to contain_package('check_mk-agent').with(
               {
                 provider: 'rpm',
                 source: '/workspace/check_mk-agent-1.2.3.noarch.rpm',
@@ -74,9 +74,9 @@ describe 'check_mk::agent::install' do
         end
       when 'Debian'
         context 'with default parameters' do
-          it { should contain_class('check_mk::agent::install') }
-          it { should contain_package('xinetd') }
-          it { should contain_package('check_mk-agent').with_name('check-mk-agent') }
+          it { is_expected.to contain_class('check_mk::agent::install') }
+          it { is_expected.to contain_package('xinetd') }
+          it { is_expected.to contain_package('check_mk-agent').with_name('check-mk-agent') }
         end
 
         context 'with custom package' do
@@ -85,9 +85,9 @@ describe 'check_mk::agent::install' do
               package: 'custom-package',
             }
           end
-          it { should contain_class('check_mk::agent::install') }
-          it { should contain_package('xinetd') }
-          it { should contain_package('check_mk-agent').with_name('custom-package') }
+          it { is_expected.to contain_class('check_mk::agent::install') }
+          it { is_expected.to contain_package('xinetd') }
+          it { is_expected.to contain_package('check_mk-agent').with_name('custom-package') }
         end
       end
     end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -41,7 +41,7 @@ describe 'check_mk::agent::install' do
               }
             end
 
-            it 'should fail' do
+            it 'fails' do
               expect { catalogue }.to raise_error(Puppet::Error, /version must be specified/)
             end
           end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -9,12 +9,13 @@ describe 'check_mk::agent::install' do
       case facts[:osfamily]
       when 'Redhat'
         context 'with default parameters' do
-          it { is_expected.to contain_class('check_mk::agent::install').with(
-            version: nil,
-            filestore: nil,
-            workspace: '/root/check_mk',
-            package: nil
-          )
+          it {
+            is_expected.to contain_class('check_mk::agent::install').with(
+              version: nil,
+              filestore: nil,
+              workspace: '/root/check_mk',
+              package: nil
+            )
           }
           it { is_expected.to contain_package('xinetd') }
           it { is_expected.to contain_package('check_mk-agent').with_name('check-mk-agent') }
@@ -56,16 +57,18 @@ describe 'check_mk::agent::install' do
             it { is_expected.to contain_class('check_mk::agent::install') }
             it { is_expected.to contain_package('xinetd') }
             it { is_expected.to contain_file('/workspace').with_ensure('directory') }
-            it { is_expected.to contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
-              ensure: 'present',
-              source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
-              require: 'Package[xinetd]'
-            ).that_comes_before('Package[check_mk-agent]')
+            it {
+              is_expected.to contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
+                ensure: 'present',
+                source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
+                require: 'Package[xinetd]'
+              ).that_comes_before('Package[check_mk-agent]')
             }
-            it { is_expected.to contain_package('check_mk-agent').with(
-              provider: 'rpm',
-              source: '/workspace/check_mk-agent-1.2.3.noarch.rpm'
-            )
+            it {
+              is_expected.to contain_package('check_mk-agent').with(
+                provider: 'rpm',
+                source: '/workspace/check_mk-agent-1.2.3.noarch.rpm'
+              )
             }
           end
         end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -10,12 +10,10 @@ describe 'check_mk::agent::install' do
       when 'Redhat'
         context 'with default parameters' do
           it { is_expected.to contain_class('check_mk::agent::install').with(
-            {
-              version: nil,
-              filestore: nil,
-              workspace: '/root/check_mk',
-              package: nil
-            }
+            version: nil,
+            filestore: nil,
+            workspace: '/root/check_mk',
+            package: nil
           )
           }
           it { is_expected.to contain_package('xinetd') }
@@ -59,18 +57,14 @@ describe 'check_mk::agent::install' do
             it { is_expected.to contain_package('xinetd') }
             it { is_expected.to contain_file('/workspace').with_ensure('directory') }
             it { is_expected.to contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
-              {
-                ensure: 'present',
-                source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
-                require: 'Package[xinetd]'
-              }
+              ensure: 'present',
+              source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
+              require: 'Package[xinetd]'
             ).that_comes_before('Package[check_mk-agent]')
             }
             it { is_expected.to contain_package('check_mk-agent').with(
-              {
-                provider: 'rpm',
-                source: '/workspace/check_mk-agent-1.2.3.noarch.rpm'
-              }
+              provider: 'rpm',
+              source: '/workspace/check_mk-agent-1.2.3.noarch.rpm'
             )
             }
           end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -11,10 +11,10 @@ describe 'check_mk::agent::install' do
         context 'with default parameters' do
           it { should contain_class('check_mk::agent::install').with(
             {
-              :version   => nil,
-              :filestore => nil,
-              :workspace => '/root/check_mk',
-              :package   => nil,
+              version: nil,
+              filestore: nil,
+              workspace: '/root/check_mk',
+              package: nil,
             }
           )
           }
@@ -25,7 +25,7 @@ describe 'check_mk::agent::install' do
         context 'with custom package' do
           let :params do
             {
-              :package => 'custom-package',
+              package: 'custom-package',
             }
           end
           it { should contain_class('check_mk::agent::install') }
@@ -37,7 +37,7 @@ describe 'check_mk::agent::install' do
           context 'without version' do
             let :params do
               {
-                :filestore => '/filestore',
+                filestore: '/filestore',
               }
             end
             it 'should fail' do
@@ -47,9 +47,9 @@ describe 'check_mk::agent::install' do
           context 'with custom parameters' do
             let :params do
               {
-                :version   => '1.2.3',
-                :filestore => '/filestore',
-                :workspace => '/workspace',
+                version: '1.2.3',
+                filestore: '/filestore',
+                workspace: '/workspace',
               }
             end
             it { should contain_class('check_mk::agent::install') }
@@ -57,16 +57,16 @@ describe 'check_mk::agent::install' do
             it { should contain_file('/workspace').with_ensure('directory') }
             it { should contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
               {
-                :ensure  => 'present',
-                :source  => '/filestore/check_mk-agent-1.2.3.noarch.rpm',
-                :require => 'Package[xinetd]',
+                ensure: 'present',
+                source: '/filestore/check_mk-agent-1.2.3.noarch.rpm',
+                require: 'Package[xinetd]',
               }
             ).that_comes_before('Package[check_mk-agent]')
             }
             it { should contain_package('check_mk-agent').with(
               {
-                :provider => 'rpm',
-                :source   => '/workspace/check_mk-agent-1.2.3.noarch.rpm',
+                provider: 'rpm',
+                source: '/workspace/check_mk-agent-1.2.3.noarch.rpm',
               }
             )
             }
@@ -82,7 +82,7 @@ describe 'check_mk::agent::install' do
         context 'with custom package' do
           let :params do
             {
-              :package => 'custom-package',
+              package: 'custom-package',
             }
           end
           it { should contain_class('check_mk::agent::install') }

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -8,18 +8,18 @@ describe 'check_mk::agent::service', type: :class do
 
       it { is_expected.to contain_class('check_mk::agent::service') }
       it { is_expected.to contain_service('xinetd').with({
-        ensure: 'running',
-        enable: true
-      })
+                                                           ensure: 'running',
+                                                           enable: true
+                                                         })
       }
 
       if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
         it { is_expected.to contain_class('check_mk::agent::service') }
         it { is_expected.to contain_service('xinetd').with({
-          ensure: 'running',
-          enable: true,
-          hasstatus: false
-        })
+                                                             ensure: 'running',
+                                                             enable: true,
+                                                             hasstatus: false
+                                                           })
         }
       end
     end

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -12,7 +12,7 @@ describe 'check_mk::agent::service', type: :class do
                                                       enable: true)
       }
 
-      if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
+      if facts[:osfamily] == 'Debian' && facts[:operatingsystemmajrelease] == '7'
         it { is_expected.to contain_class('check_mk::agent::service') }
         it {
           is_expected.to contain_service('xinetd').with(ensure: 'running',

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -9,7 +9,7 @@ describe 'check_mk::agent::service', type: :class do
       it { is_expected.to contain_class('check_mk::agent::service') }
       it { is_expected.to contain_service('xinetd').with({
         ensure: 'running',
-        enable: true,
+        enable: true
       })
       }
 
@@ -18,7 +18,7 @@ describe 'check_mk::agent::service', type: :class do
         it { is_expected.to contain_service('xinetd').with({
           ensure: 'running',
           enable: true,
-          hasstatus: false,
+          hasstatus: false
         })
         }
       end

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -7,15 +7,17 @@ describe 'check_mk::agent::service', type: :class do
       end
 
       it { is_expected.to contain_class('check_mk::agent::service') }
-      it { is_expected.to contain_service('xinetd').with(ensure: 'running',
-                                                         enable: true)
+      it {
+        is_expected.to contain_service('xinetd').with(ensure: 'running',
+                                                      enable: true)
       }
 
       if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
         it { is_expected.to contain_class('check_mk::agent::service') }
-        it { is_expected.to contain_service('xinetd').with(ensure: 'running',
-                                                           enable: true,
-                                                           hasstatus: false)
+        it {
+          is_expected.to contain_service('xinetd').with(ensure: 'running',
+                                                        enable: true,
+                                                        hasstatus: false)
         }
       end
     end

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -6,16 +6,16 @@ describe 'check_mk::agent::service', type: :class do
         facts
       end
 
-      it { should contain_class('check_mk::agent::service') }
-      it { should contain_service('xinetd').with({
+      it { is_expected.to contain_class('check_mk::agent::service') }
+      it { is_expected.to contain_service('xinetd').with({
         ensure: 'running',
         enable: true,
       })
       }
 
       if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
-        it { should contain_class('check_mk::agent::service') }
-        it { should contain_service('xinetd').with({
+        it { is_expected.to contain_class('check_mk::agent::service') }
+        it { is_expected.to contain_service('xinetd').with({
           ensure: 'running',
           enable: true,
           hasstatus: false,

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -13,7 +13,6 @@ describe 'check_mk::agent::service', type: :class do
       }
 
       if facts[:osfamily] == 'Debian' && facts[:operatingsystemmajrelease] == '7'
-        it { is_expected.to contain_class('check_mk::agent::service') }
         it {
           is_expected.to contain_service('xinetd').with(ensure: 'running',
                                                         enable: true,

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe 'check_mk::agent::service', :type => :class do
+describe 'check_mk::agent::service', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
@@ -8,17 +8,17 @@ describe 'check_mk::agent::service', :type => :class do
 
       it { should contain_class('check_mk::agent::service') }
       it { should contain_service('xinetd').with({
-        :ensure => 'running',
-        :enable => true,
+        ensure: 'running',
+        enable: true,
       })
       }
 
       if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
         it { should contain_class('check_mk::agent::service') }
         it { should contain_service('xinetd').with({
-          :ensure    => 'running',
-          :enable    => true,
-          :hasstatus => false,
+          ensure: 'running',
+          enable: true,
+          hasstatus: false,
         })
         }
       end

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -7,19 +7,15 @@ describe 'check_mk::agent::service', type: :class do
       end
 
       it { is_expected.to contain_class('check_mk::agent::service') }
-      it { is_expected.to contain_service('xinetd').with({
-                                                           ensure: 'running',
-                                                           enable: true
-                                                         })
+      it { is_expected.to contain_service('xinetd').with(ensure: 'running',
+                                                         enable: true)
       }
 
       if facts[:osfamily] == 'Debian' and facts[:operatingsystemmajrelease] == '7'
         it { is_expected.to contain_class('check_mk::agent::service') }
-        it { is_expected.to contain_service('xinetd').with({
-                                                             ensure: 'running',
-                                                             enable: true,
-                                                             hasstatus: false
-                                                           })
+        it { is_expected.to contain_service('xinetd').with(ensure: 'running',
+                                                           enable: true,
+                                                           hasstatus: false)
         }
       end
     end

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -23,7 +23,7 @@ describe 'check_mk::agent', type: :class do
           }
         end
 
-        it 'should fail' do
+        it 'fails' do
           expect { catalogue }.to raise_error(Puppet::Error, /\"not_a_hash\" is not a Hash./)
         end
       end

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -5,7 +5,7 @@ describe 'check_mk::agent', type: :class do
       {
           kernel: 'Linux',
           operatingsystem: 'Redhat',
-          osfamily: 'Redhat',
+          osfamily: 'Redhat'
       }
     end
     context 'with defaults for all parameters' do
@@ -18,7 +18,7 @@ describe 'check_mk::agent', type: :class do
       context 'not a hash' do
         let :params do
           {
-              mrpe_checks: 'not_a_hash',
+              mrpe_checks: 'not_a_hash'
           }
         end
         it 'should fail' do
@@ -30,7 +30,7 @@ describe 'check_mk::agent', type: :class do
           {
               mrpe_checks: {
                   'check1' => {'command' => 'command1'},
-                  'check2' => {'command' => 'command2'},
+                  'check2' => {'command' => 'command2'}
               }
           }
         end

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -24,7 +24,7 @@ describe 'check_mk::agent', type: :class do
         end
 
         it 'fails' do
-          expect { catalogue }.to raise_error(Puppet::Error, /\"not_a_hash\" is not a Hash./)
+          expect { catalogue }.to raise_error(Puppet::Error, %r{\"not_a_hash\" is not a Hash.})
         end
       end
       context 'defined correctly' do

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -9,10 +9,10 @@ describe 'check_mk::agent', type: :class do
       }
     end
     context 'with defaults for all parameters' do
-      it { should contain_class('check_mk::agent') }
-      it { should contain_class('check_mk::agent::install').that_comes_before('Class[check_mk::agent::config]') }
-      it { should contain_class('check_mk::agent::config') }
-      it { should contain_class('check_mk::agent::service') }
+      it { is_expected.to contain_class('check_mk::agent') }
+      it { is_expected.to contain_class('check_mk::agent::install').that_comes_before('Class[check_mk::agent::config]') }
+      it { is_expected.to contain_class('check_mk::agent::config') }
+      it { is_expected.to contain_class('check_mk::agent::service') }
     end
     context 'with mrpe_checks' do
       context 'not a hash' do
@@ -34,9 +34,9 @@ describe 'check_mk::agent', type: :class do
               }
           }
         end
-        it { should contain_class('check_mk::agent') }
-        it { should contain_check_mk__agent__mrpe('check1').with_command('command1') }
-        it { should contain_check_mk__agent__mrpe('check2').with_command('command2') }
+        it { is_expected.to contain_class('check_mk::agent') }
+        it { is_expected.to contain_check_mk__agent__mrpe('check1').with_command('command1') }
+        it { is_expected.to contain_check_mk__agent__mrpe('check2').with_command('command2') }
       end
     end
   end

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -31,8 +31,8 @@ describe 'check_mk::agent', type: :class do
         let :params do
           {
             mrpe_checks: {
-              'check1' => {'command' => 'command1'},
-              'check2' => {'command' => 'command2'}
+              'check1' => { 'command' => 'command1' },
+              'check2' => { 'command' => 'command2' }
             }
           }
         end

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
-describe 'check_mk::agent', :type => :class do
+describe 'check_mk::agent', type: :class do
   context 'Redhat Linux' do
     let :facts do
       {
-          :kernel          => 'Linux',
-          :operatingsystem => 'Redhat',
-          :osfamily        => 'Redhat',
+          kernel: 'Linux',
+          operatingsystem: 'Redhat',
+          osfamily: 'Redhat',
       }
     end
     context 'with defaults for all parameters' do
@@ -18,7 +18,7 @@ describe 'check_mk::agent', :type => :class do
       context 'not a hash' do
         let :params do
           {
-              :mrpe_checks => 'not_a_hash',
+              mrpe_checks: 'not_a_hash',
           }
         end
         it 'should fail' do
@@ -28,7 +28,7 @@ describe 'check_mk::agent', :type => :class do
       context 'defined correctly' do
         let :params do
           {
-              :mrpe_checks => {
+              mrpe_checks: {
                   'check1' => {'command' => 'command1'},
                   'check2' => {'command' => 'command2'},
               }

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -8,6 +8,7 @@ describe 'check_mk::agent', type: :class do
         osfamily: 'Redhat'
       }
     end
+
     context 'with defaults for all parameters' do
       it { is_expected.to contain_class('check_mk::agent') }
       it { is_expected.to contain_class('check_mk::agent::install').that_comes_before('Class[check_mk::agent::config]') }
@@ -21,6 +22,7 @@ describe 'check_mk::agent', type: :class do
             mrpe_checks: 'not_a_hash'
           }
         end
+
         it 'should fail' do
           expect { catalogue }.to raise_error(Puppet::Error, /\"not_a_hash\" is not a Hash./)
         end
@@ -34,6 +36,7 @@ describe 'check_mk::agent', type: :class do
             }
           }
         end
+
         it { is_expected.to contain_class('check_mk::agent') }
         it { is_expected.to contain_check_mk__agent__mrpe('check1').with_command('command1') }
         it { is_expected.to contain_check_mk__agent__mrpe('check2').with_command('command2') }

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -3,9 +3,9 @@ describe 'check_mk::agent', type: :class do
   context 'Redhat Linux' do
     let :facts do
       {
-          kernel: 'Linux',
-          operatingsystem: 'Redhat',
-          osfamily: 'Redhat'
+        kernel: 'Linux',
+        operatingsystem: 'Redhat',
+        osfamily: 'Redhat'
       }
     end
     context 'with defaults for all parameters' do
@@ -18,7 +18,7 @@ describe 'check_mk::agent', type: :class do
       context 'not a hash' do
         let :params do
           {
-              mrpe_checks: 'not_a_hash'
+            mrpe_checks: 'not_a_hash'
           }
         end
         it 'should fail' do
@@ -28,10 +28,10 @@ describe 'check_mk::agent', type: :class do
       context 'defined correctly' do
         let :params do
           {
-              mrpe_checks: {
-                  'check1' => {'command' => 'command1'},
-                  'check2' => {'command' => 'command2'}
-              }
+            mrpe_checks: {
+              'check1' => {'command' => 'command1'},
+              'check2' => {'command' => 'command2'}
+            }
           }
         end
         it { is_expected.to contain_class('check_mk::agent') }

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -6,7 +6,7 @@ describe 'check_mk::config', type: :class do
   context 'with site set' do
     let :params do
       {
-          site: 'TEST_SITE'
+        site: 'TEST_SITE'
       }
     end
     it { is_expected.to contain_class('check_mk::config') }
@@ -14,114 +14,114 @@ describe 'check_mk::config', type: :class do
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
     it { is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with({
-          ensure: 'present',
-          line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
-          path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
-          notify: 'Class[Check_mk::Service]'
-      })
+                                                                                ensure: 'present',
+                                                                                line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
+                                                                                path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
+                                                                                notify: 'Class[Check_mk::Service]'
+                                                                              })
     }
     it { is_expected.to contain_file_line('add-guest-users').with({
-          ensure: 'present',
-          line: 'guest_users = [ "guest" ]',
-          path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk'
-      })
+                                                                    ensure: 'present',
+                                                                    line: 'guest_users = [ "guest" ]',
+                                                                    path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk'
+                                                                  })
     }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
-          ensure: 'file',
-          content: ''
-      })
+                                                                                                  ensure: 'file',
+                                                                                                  content: ''
+                                                                                                })
     }
     it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
-          owner: 'root',
-          group: 'root',
-          mode: 'u=rw,go=r',
-          notify: 'Exec[check_mk-refresh]'
-      })
+                                                                                           owner: 'root',
+                                                                                           group: 'root',
+                                                                                           mode: 'u=rw,go=r',
+                                                                                           notify: 'Exec[check_mk-refresh]'
+                                                                                         })
     }
     it { is_expected.to contain_concat__fragment('all_hosts-header').with({
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          content: /all_hosts = \[\n/,
-          order: 10
-      })
+                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            content: /all_hosts = \[\n/,
+                                                                            order: 10
+                                                                          })
     }
     it { is_expected.to contain_concat__fragment('all_hosts-footer').with({
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          content: /\]\n/,
-          order: 19
-      })
+                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            content: /\]\n/,
+                                                                            order: 19
+                                                                          })
     }
     it { is_expected.to contain_concat__fragment('all-hosts-static').with({
-          source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          order: 18
-      })
+                                                                            source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
+                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            order: 18
+                                                                          })
     }
     it { is_expected.not_to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
     it { is_expected.not_to contain_concat__fragment('host_groups-header') }
     it { is_expected.not_to contain_concat__fragment('host_groups-footer') }
     it { is_expected.to have_check_mk__hostgroup_resource_count(0) }
     it { is_expected.to contain_concat__fragment('check_mk-local-config').with({
-          source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          order: 99
-      })
+                                                                                 source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
+                                                                                 target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                                 order: 99
+                                                                               })
     }
     it { is_expected.to contain_exec('check_mk-refresh').with({
-          command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
-          refreshonly: true
-      })
+                                                                command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
+                                                                refreshonly: true
+                                                              })
     }
     it { is_expected.to contain_exec('check_mk-reload').with({
-          command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-          refreshonly: true
-      })
+                                                               command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                               refreshonly: true
+                                                             })
     }
     it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with({
-          user: 'root',
-          command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-          minute: 0,
-          hour: 0
-      })
+                                                                                user: 'root',
+                                                                                command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                                                minute: 0,
+                                                                                hour: 0
+                                                                              })
     }
   end
   context 'with host_groups' do
     host_groups = {
-        'group1' => {'host_tags' => []},
-        'group2' => {'host_tags' => []}
+      'group1' => {'host_tags' => []},
+      'group2' => {'host_tags' => []}
     }
     let :params do
       {
-          site: 'TEST_SITE',
-          host_groups: host_groups
+        site: 'TEST_SITE',
+        host_groups: host_groups
       }
     end
     it { is_expected.to contain_class('check_mk::config') }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
     it { is_expected.to contain_concat__fragment('host_groups-header').with({
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          content: /host_groups = \[\n/,
-          order: 20
-      })
+                                                                              target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                              content: /host_groups = \[\n/,
+                                                                              order: 20
+                                                                            })
     }
     it { is_expected.to contain_concat__fragment('host_groups-footer').with({
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          content: /\]\n/,
-          order: 29
-      })
+                                                                              target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                              content: /\]\n/,
+                                                                              order: 29
+                                                                            })
     }
     it { is_expected.to contain_check_mk__hostgroup('group1').with({
-          dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-          hostgroups: host_groups,
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          notify: 'Exec[check_mk-refresh]'
-      })
+                                                                     dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                     hostgroups: host_groups,
+                                                                     target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                     notify: 'Exec[check_mk-refresh]'
+                                                                   })
     }
     it { is_expected.to contain_check_mk__hostgroup('group2').with({
-          dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-          hostgroups: host_groups,
-          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          notify: 'Exec[check_mk-refresh]'
-      })
+                                                                     dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                     hostgroups: host_groups,
+                                                                     target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                     notify: 'Exec[check_mk-refresh]'
+                                                                   })
     }
   end
 end

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
-describe 'check_mk::config', :type => :class do
+describe 'check_mk::config', type: :class do
   # Mock check_mk::service class.
   let(:pre_condition) { "class check_mk::service{}\n include check_mk::service" }
 
   context 'with site set' do
     let :params do
       {
-          :site => 'TEST_SITE'
+          site: 'TEST_SITE'
       }
     end
     it { should contain_class('check_mk::config') }
@@ -14,46 +14,46 @@ describe 'check_mk::config', :type => :class do
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
     it { should contain_file_line('nagios-add-check_mk-cfg_dir').with({
-          :ensure => 'present',
-          :line   => 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
-          :path   => '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
-          :notify => 'Class[Check_mk::Service]',
+          ensure: 'present',
+          line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
+          path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
+          notify: 'Class[Check_mk::Service]',
       })
     }
     it { should contain_file_line('add-guest-users').with({
-          :ensure => 'present',
-          :line   => 'guest_users = [ "guest" ]',
-          :path   => '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk',
+          ensure: 'present',
+          line: 'guest_users = [ "guest" ]',
+          path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk',
       })
     }
     it { should contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
-          :ensure  => 'file',
-          :content => '',
+          ensure: 'file',
+          content: '',
       })
     }
     it { should contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
-          :owner  => 'root',
-          :group  => 'root',
-          :mode   => 'u=rw,go=r',
-          :notify => 'Exec[check_mk-refresh]',
+          owner: 'root',
+          group: 'root',
+          mode: 'u=rw,go=r',
+          notify: 'Exec[check_mk-refresh]',
       })
     }
     it { should contain_concat__fragment('all_hosts-header').with({
-          :target  => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :content => /all_hosts = \[\n/,
-          :order  => 10,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          content: /all_hosts = \[\n/,
+          order: 10,
       })
     }
     it { should contain_concat__fragment('all_hosts-footer').with({
-          :target => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :content => /\]\n/,
-          :order  => 19,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          content: /\]\n/,
+          order: 19,
       })
     }
     it { should contain_concat__fragment('all-hosts-static').with({
-          :source => '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
-          :target => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :order  => 18,
+          source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          order: 18,
       })
     }
     it { should_not contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
@@ -61,26 +61,26 @@ describe 'check_mk::config', :type => :class do
     it { should_not contain_concat__fragment('host_groups-footer') }
     it { should have_check_mk__hostgroup_resource_count(0) }
     it { should contain_concat__fragment('check_mk-local-config').with({
-          :source => '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
-          :target => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :order  => 99,
+          source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          order: 99,
       })
     }
     it { should contain_exec('check_mk-refresh').with({
-          :command     => /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
-          :refreshonly => true,
+          command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
+          refreshonly: true,
       })
     }
     it { should contain_exec('check_mk-reload').with({
-          :command     => /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-          :refreshonly => true,
+          command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+          refreshonly: true,
       })
     }
     it { should contain_cron('check_mk-refresh-inventory-daily').with({
-          :user    => 'root',
-          :command => /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-          :minute  => 0,
-          :hour    => 0,
+          user: 'root',
+          command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+          minute: 0,
+          hour: 0,
       })
     }
   end
@@ -91,36 +91,36 @@ describe 'check_mk::config', :type => :class do
     }
     let :params do
       {
-          :site => 'TEST_SITE',
-          :host_groups => host_groups,
+          site: 'TEST_SITE',
+          host_groups: host_groups,
       }
     end
     it { should contain_class('check_mk::config') }
     it { should contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
     it { should contain_concat__fragment('host_groups-header').with({
-          :target => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :content => /host_groups = \[\n/,
-          :order  => 20,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          content: /host_groups = \[\n/,
+          order: 20,
       })
     }
     it { should contain_concat__fragment('host_groups-footer').with({
-          :target => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :content => /\]\n/,
-          :order  => 29,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          content: /\]\n/,
+          order: 29,
       })
     }
     it { should contain_check_mk__hostgroup('group1').with({
-          :dir        => '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-          :hostgroups => host_groups,
-          :target     => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :notify     => 'Exec[check_mk-refresh]',
+          dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+          hostgroups: host_groups,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          notify: 'Exec[check_mk-refresh]',
       })
     }
     it { should contain_check_mk__hostgroup('group2').with({
-          :dir        => '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-          :hostgroups => host_groups,
-          :target     => '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          :notify     => 'Exec[check_mk-refresh]',
+          dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+          hostgroups: host_groups,
+          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+          notify: 'Exec[check_mk-refresh]',
       })
     }
   end

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -61,16 +61,16 @@ describe 'check_mk::config', type: :class do
                                                                             order: 99)
     }
     it {
-      is_expected.to contain_exec('check_mk-refresh').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
+      is_expected.to contain_exec('check_mk-refresh').with(command: %r{/bin/su -l -c '/omd/sites/TEST_SITE/bin/check_mk -I' TEST_SITE},
                                                            refreshonly: true)
     }
     it {
-      is_expected.to contain_exec('check_mk-reload').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+      is_expected.to contain_exec('check_mk-reload').with(command: %r{/bin/su -l -c '/omd/sites/TEST_SITE/bin/check_mk -O' TEST_SITE},
                                                           refreshonly: true)
     }
     it {
       is_expected.to contain_cron('check_mk-refresh-inventory-daily').with(user: 'root',
-                                                                           command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                                           command: %r{su -l -c '/omd/sites/TEST_SITE/bin/check_mk -O' TEST_SITE},
                                                                            minute: 0,
                                                                            hour: 0)
     }

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -9,6 +9,7 @@ describe 'check_mk::config', type: :class do
         site: 'TEST_SITE'
       }
     end
+
     it { is_expected.to contain_class('check_mk::config') }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
@@ -95,6 +96,7 @@ describe 'check_mk::config', type: :class do
         host_groups: host_groups
       }
     end
+
     it { is_expected.to contain_class('check_mk::config') }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
     it { is_expected.to contain_concat__fragment('host_groups-header').with({

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -11,56 +11,68 @@ describe 'check_mk::config', type: :class do
     end
 
     it { is_expected.to contain_class('check_mk::config') }
-    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
+    it {
+      is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
-    it { is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with(ensure: 'present',
-                                                                              line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
-                                                                              path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
-                                                                              notify: 'Class[Check_mk::Service]')
+    it {
+      is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with(ensure: 'present',
+                                                                           line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
+                                                                           path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
+                                                                           notify: 'Class[Check_mk::Service]')
     }
-    it { is_expected.to contain_file_line('add-guest-users').with(ensure: 'present',
-                                                                  line: 'guest_users = [ "guest" ]',
-                                                                  path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk')
+    it {
+      is_expected.to contain_file_line('add-guest-users').with(ensure: 'present',
+                                                               line: 'guest_users = [ "guest" ]',
+                                                               path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk')
     }
-    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with(ensure: 'file',
-                                                                                                content: '')
+    it {
+      is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with(ensure: 'file',
+                                                                                             content: '')
     }
-    it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with(owner: 'root',
-                                                                                         group: 'root',
-                                                                                         mode: 'u=rw,go=r',
-                                                                                         notify: 'Exec[check_mk-refresh]')
+    it {
+      is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with(owner: 'root',
+                                                                                      group: 'root',
+                                                                                      mode: 'u=rw,go=r',
+                                                                                      notify: 'Exec[check_mk-refresh]')
     }
-    it { is_expected.to contain_concat__fragment('all_hosts-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                          content: /all_hosts = \[\n/,
-                                                                          order: 10)
+    it {
+      is_expected.to contain_concat__fragment('all_hosts-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                       content: /all_hosts = \[\n/,
+                                                                       order: 10)
     }
-    it { is_expected.to contain_concat__fragment('all_hosts-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                          content: /\]\n/,
-                                                                          order: 19)
+    it {
+      is_expected.to contain_concat__fragment('all_hosts-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                       content: /\]\n/,
+                                                                       order: 19)
     }
-    it { is_expected.to contain_concat__fragment('all-hosts-static').with(source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
-                                                                          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                          order: 18)
+    it {
+      is_expected.to contain_concat__fragment('all-hosts-static').with(source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
+                                                                       target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                       order: 18)
     }
     it { is_expected.not_to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
     it { is_expected.not_to contain_concat__fragment('host_groups-header') }
     it { is_expected.not_to contain_concat__fragment('host_groups-footer') }
     it { is_expected.to have_check_mk__hostgroup_resource_count(0) }
-    it { is_expected.to contain_concat__fragment('check_mk-local-config').with(source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
-                                                                               target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                               order: 99)
+    it {
+      is_expected.to contain_concat__fragment('check_mk-local-config').with(source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
+                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            order: 99)
     }
-    it { is_expected.to contain_exec('check_mk-refresh').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
-                                                              refreshonly: true)
+    it {
+      is_expected.to contain_exec('check_mk-refresh').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
+                                                           refreshonly: true)
     }
-    it { is_expected.to contain_exec('check_mk-reload').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-                                                             refreshonly: true)
+    it {
+      is_expected.to contain_exec('check_mk-reload').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                          refreshonly: true)
     }
-    it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with(user: 'root',
-                                                                              command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-                                                                              minute: 0,
-                                                                              hour: 0)
+    it {
+      is_expected.to contain_cron('check_mk-refresh-inventory-daily').with(user: 'root',
+                                                                           command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                                           minute: 0,
+                                                                           hour: 0)
     }
   end
   context 'with host_groups' do
@@ -77,23 +89,27 @@ describe 'check_mk::config', type: :class do
 
     it { is_expected.to contain_class('check_mk::config') }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
-    it { is_expected.to contain_concat__fragment('host_groups-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                            content: /host_groups = \[\n/,
-                                                                            order: 20)
+    it {
+      is_expected.to contain_concat__fragment('host_groups-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                         content: /host_groups = \[\n/,
+                                                                         order: 20)
     }
-    it { is_expected.to contain_concat__fragment('host_groups-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                            content: /\]\n/,
-                                                                            order: 29)
+    it {
+      is_expected.to contain_concat__fragment('host_groups-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                         content: /\]\n/,
+                                                                         order: 29)
     }
-    it { is_expected.to contain_check_mk__hostgroup('group1').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-                                                                   hostgroups: host_groups,
-                                                                   target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                   notify: 'Exec[check_mk-refresh]')
+    it {
+      is_expected.to contain_check_mk__hostgroup('group1').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                hostgroups: host_groups,
+                                                                target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                notify: 'Exec[check_mk-refresh]')
     }
-    it { is_expected.to contain_check_mk__hostgroup('group2').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-                                                                   hostgroups: host_groups,
-                                                                   target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                   notify: 'Exec[check_mk-refresh]')
+    it {
+      is_expected.to contain_check_mk__hostgroup('group2').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                hostgroups: host_groups,
+                                                                target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                notify: 'Exec[check_mk-refresh]')
     }
   end
 end

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -17,43 +17,43 @@ describe 'check_mk::config', type: :class do
           ensure: 'present',
           line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
           path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
-          notify: 'Class[Check_mk::Service]',
+          notify: 'Class[Check_mk::Service]'
       })
     }
     it { is_expected.to contain_file_line('add-guest-users').with({
           ensure: 'present',
           line: 'guest_users = [ "guest" ]',
-          path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk',
+          path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk'
       })
     }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
           ensure: 'file',
-          content: '',
+          content: ''
       })
     }
     it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
           owner: 'root',
           group: 'root',
           mode: 'u=rw,go=r',
-          notify: 'Exec[check_mk-refresh]',
+          notify: 'Exec[check_mk-refresh]'
       })
     }
     it { is_expected.to contain_concat__fragment('all_hosts-header').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /all_hosts = \[\n/,
-          order: 10,
+          order: 10
       })
     }
     it { is_expected.to contain_concat__fragment('all_hosts-footer').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /\]\n/,
-          order: 19,
+          order: 19
       })
     }
     it { is_expected.to contain_concat__fragment('all-hosts-static').with({
           source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          order: 18,
+          order: 18
       })
     }
     it { is_expected.not_to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
@@ -63,36 +63,36 @@ describe 'check_mk::config', type: :class do
     it { is_expected.to contain_concat__fragment('check_mk-local-config').with({
           source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          order: 99,
+          order: 99
       })
     }
     it { is_expected.to contain_exec('check_mk-refresh').with({
           command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
-          refreshonly: true,
+          refreshonly: true
       })
     }
     it { is_expected.to contain_exec('check_mk-reload').with({
           command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-          refreshonly: true,
+          refreshonly: true
       })
     }
     it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with({
           user: 'root',
           command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
           minute: 0,
-          hour: 0,
+          hour: 0
       })
     }
   end
   context 'with host_groups' do
     host_groups = {
         'group1' => {'host_tags' => []},
-        'group2' => {'host_tags' => []},
+        'group2' => {'host_tags' => []}
     }
     let :params do
       {
           site: 'TEST_SITE',
-          host_groups: host_groups,
+          host_groups: host_groups
       }
     end
     it { is_expected.to contain_class('check_mk::config') }
@@ -100,27 +100,27 @@ describe 'check_mk::config', type: :class do
     it { is_expected.to contain_concat__fragment('host_groups-header').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /host_groups = \[\n/,
-          order: 20,
+          order: 20
       })
     }
     it { is_expected.to contain_concat__fragment('host_groups-footer').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /\]\n/,
-          order: 29,
+          order: 29
       })
     }
     it { is_expected.to contain_check_mk__hostgroup('group1').with({
           dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
           hostgroups: host_groups,
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          notify: 'Exec[check_mk-refresh]',
+          notify: 'Exec[check_mk-refresh]'
       })
     }
     it { is_expected.to contain_check_mk__hostgroup('group2').with({
           dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
           hostgroups: host_groups,
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-          notify: 'Exec[check_mk-refresh]',
+          notify: 'Exec[check_mk-refresh]'
       })
     }
   end

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -13,7 +13,7 @@ describe 'check_mk::config', type: :class do
     it { is_expected.to contain_class('check_mk::config') }
     it {
       is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
-                    that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
+        that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
     it {
       is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with(ensure: 'present',

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -38,12 +38,12 @@ describe 'check_mk::config', type: :class do
     }
     it {
       is_expected.to contain_concat__fragment('all_hosts-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                       content: /all_hosts = \[\n/,
+                                                                       content: %r{all_hosts = \[\n},
                                                                        order: 10)
     }
     it {
       is_expected.to contain_concat__fragment('all_hosts-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                       content: /\]\n/,
+                                                                       content: %r{\]\n},
                                                                        order: 19)
     }
     it {
@@ -91,12 +91,12 @@ describe 'check_mk::config', type: :class do
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
     it {
       is_expected.to contain_concat__fragment('host_groups-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                         content: /host_groups = \[\n/,
+                                                                         content: %r{host_groups = \[\n},
                                                                          order: 20)
     }
     it {
       is_expected.to contain_concat__fragment('host_groups-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                         content: /\]\n/,
+                                                                         content: %r{\]\n},
                                                                          order: 29)
     }
     it {

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -14,75 +14,53 @@ describe 'check_mk::config', type: :class do
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
-    it { is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with({
-                                                                                ensure: 'present',
-                                                                                line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
-                                                                                path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
-                                                                                notify: 'Class[Check_mk::Service]'
-                                                                              })
+    it { is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with(ensure: 'present',
+                                                                              line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
+                                                                              path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
+                                                                              notify: 'Class[Check_mk::Service]')
     }
-    it { is_expected.to contain_file_line('add-guest-users').with({
-                                                                    ensure: 'present',
-                                                                    line: 'guest_users = [ "guest" ]',
-                                                                    path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk'
-                                                                  })
+    it { is_expected.to contain_file_line('add-guest-users').with(ensure: 'present',
+                                                                  line: 'guest_users = [ "guest" ]',
+                                                                  path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk')
     }
-    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
-                                                                                                  ensure: 'file',
-                                                                                                  content: ''
-                                                                                                })
+    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with(ensure: 'file',
+                                                                                                content: '')
     }
-    it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
-                                                                                           owner: 'root',
-                                                                                           group: 'root',
-                                                                                           mode: 'u=rw,go=r',
-                                                                                           notify: 'Exec[check_mk-refresh]'
-                                                                                         })
+    it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with(owner: 'root',
+                                                                                         group: 'root',
+                                                                                         mode: 'u=rw,go=r',
+                                                                                         notify: 'Exec[check_mk-refresh]')
     }
-    it { is_expected.to contain_concat__fragment('all_hosts-header').with({
-                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                            content: /all_hosts = \[\n/,
-                                                                            order: 10
-                                                                          })
+    it { is_expected.to contain_concat__fragment('all_hosts-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                          content: /all_hosts = \[\n/,
+                                                                          order: 10)
     }
-    it { is_expected.to contain_concat__fragment('all_hosts-footer').with({
-                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                            content: /\]\n/,
-                                                                            order: 19
-                                                                          })
+    it { is_expected.to contain_concat__fragment('all_hosts-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                          content: /\]\n/,
+                                                                          order: 19)
     }
-    it { is_expected.to contain_concat__fragment('all-hosts-static').with({
-                                                                            source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
-                                                                            target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                            order: 18
-                                                                          })
+    it { is_expected.to contain_concat__fragment('all-hosts-static').with(source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
+                                                                          target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                          order: 18)
     }
     it { is_expected.not_to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
     it { is_expected.not_to contain_concat__fragment('host_groups-header') }
     it { is_expected.not_to contain_concat__fragment('host_groups-footer') }
     it { is_expected.to have_check_mk__hostgroup_resource_count(0) }
-    it { is_expected.to contain_concat__fragment('check_mk-local-config').with({
-                                                                                 source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
-                                                                                 target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                                 order: 99
-                                                                               })
+    it { is_expected.to contain_concat__fragment('check_mk-local-config').with(source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
+                                                                               target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                               order: 99)
     }
-    it { is_expected.to contain_exec('check_mk-refresh').with({
-                                                                command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
-                                                                refreshonly: true
-                                                              })
+    it { is_expected.to contain_exec('check_mk-refresh').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
+                                                              refreshonly: true)
     }
-    it { is_expected.to contain_exec('check_mk-reload').with({
-                                                               command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-                                                               refreshonly: true
-                                                             })
+    it { is_expected.to contain_exec('check_mk-reload').with(command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                             refreshonly: true)
     }
-    it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with({
-                                                                                user: 'root',
-                                                                                command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
-                                                                                minute: 0,
-                                                                                hour: 0
-                                                                              })
+    it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with(user: 'root',
+                                                                              command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
+                                                                              minute: 0,
+                                                                              hour: 0)
     }
   end
   context 'with host_groups' do
@@ -99,31 +77,23 @@ describe 'check_mk::config', type: :class do
 
     it { is_expected.to contain_class('check_mk::config') }
     it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
-    it { is_expected.to contain_concat__fragment('host_groups-header').with({
-                                                                              target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                              content: /host_groups = \[\n/,
-                                                                              order: 20
-                                                                            })
+    it { is_expected.to contain_concat__fragment('host_groups-header').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            content: /host_groups = \[\n/,
+                                                                            order: 20)
     }
-    it { is_expected.to contain_concat__fragment('host_groups-footer').with({
-                                                                              target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                              content: /\]\n/,
-                                                                              order: 29
-                                                                            })
+    it { is_expected.to contain_concat__fragment('host_groups-footer').with(target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                            content: /\]\n/,
+                                                                            order: 29)
     }
-    it { is_expected.to contain_check_mk__hostgroup('group1').with({
-                                                                     dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-                                                                     hostgroups: host_groups,
-                                                                     target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                     notify: 'Exec[check_mk-refresh]'
-                                                                   })
+    it { is_expected.to contain_check_mk__hostgroup('group1').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                   hostgroups: host_groups,
+                                                                   target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                   notify: 'Exec[check_mk-refresh]')
     }
-    it { is_expected.to contain_check_mk__hostgroup('group2').with({
-                                                                     dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
-                                                                     hostgroups: host_groups,
-                                                                     target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
-                                                                     notify: 'Exec[check_mk-refresh]'
-                                                                   })
+    it { is_expected.to contain_check_mk__hostgroup('group2').with(dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
+                                                                   hostgroups: host_groups,
+                                                                   target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
+                                                                   notify: 'Exec[check_mk-refresh]')
     }
   end
 end

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -9,74 +9,74 @@ describe 'check_mk::config', type: :class do
           site: 'TEST_SITE'
       }
     end
-    it { should contain_class('check_mk::config') }
-    it { should contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
+    it { is_expected.to contain_class('check_mk::config') }
+    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local').with_ensure_directory.
                     that_comes_before('File_line[nagios-add-check_mk-cfg_dir]')
     }
-    it { should contain_file_line('nagios-add-check_mk-cfg_dir').with({
+    it { is_expected.to contain_file_line('nagios-add-check_mk-cfg_dir').with({
           ensure: 'present',
           line: 'cfg_dir=/omd/sites/TEST_SITE/etc/nagios/local',
           path: '/omd/sites/TEST_SITE/etc/nagios/nagios.cfg',
           notify: 'Class[Check_mk::Service]',
       })
     }
-    it { should contain_file_line('add-guest-users').with({
+    it { is_expected.to contain_file_line('add-guest-users').with({
           ensure: 'present',
           line: 'guest_users = [ "guest" ]',
           path: '/omd/sites/TEST_SITE/etc/check_mk/multisite.mk',
       })
     }
-    it { should contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
+    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static').with({
           ensure: 'file',
           content: '',
       })
     }
-    it { should contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
+    it { is_expected.to contain_concat('/omd/sites/TEST_SITE/etc/check_mk/main.mk').with({
           owner: 'root',
           group: 'root',
           mode: 'u=rw,go=r',
           notify: 'Exec[check_mk-refresh]',
       })
     }
-    it { should contain_concat__fragment('all_hosts-header').with({
+    it { is_expected.to contain_concat__fragment('all_hosts-header').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /all_hosts = \[\n/,
           order: 10,
       })
     }
-    it { should contain_concat__fragment('all_hosts-footer').with({
+    it { is_expected.to contain_concat__fragment('all_hosts-footer').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /\]\n/,
           order: 19,
       })
     }
-    it { should contain_concat__fragment('all-hosts-static').with({
+    it { is_expected.to contain_concat__fragment('all-hosts-static').with({
           source: '/omd/sites/TEST_SITE/etc/check_mk/all_hosts_static',
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           order: 18,
       })
     }
-    it { should_not contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
-    it { should_not contain_concat__fragment('host_groups-header') }
-    it { should_not contain_concat__fragment('host_groups-footer') }
-    it { should have_check_mk__hostgroup_resource_count(0) }
-    it { should contain_concat__fragment('check_mk-local-config').with({
+    it { is_expected.not_to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups') }
+    it { is_expected.not_to contain_concat__fragment('host_groups-header') }
+    it { is_expected.not_to contain_concat__fragment('host_groups-footer') }
+    it { is_expected.to have_check_mk__hostgroup_resource_count(0) }
+    it { is_expected.to contain_concat__fragment('check_mk-local-config').with({
           source: '/omd/sites/TEST_SITE/etc/check_mk/main.mk.local',
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           order: 99,
       })
     }
-    it { should contain_exec('check_mk-refresh').with({
+    it { is_expected.to contain_exec('check_mk-refresh').with({
           command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -I' TEST_SITE/,
           refreshonly: true,
       })
     }
-    it { should contain_exec('check_mk-reload').with({
+    it { is_expected.to contain_exec('check_mk-reload').with({
           command: /\/bin\/su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
           refreshonly: true,
       })
     }
-    it { should contain_cron('check_mk-refresh-inventory-daily').with({
+    it { is_expected.to contain_cron('check_mk-refresh-inventory-daily').with({
           user: 'root',
           command: /su -l -c '\/omd\/sites\/TEST_SITE\/bin\/check_mk -O' TEST_SITE/,
           minute: 0,
@@ -95,28 +95,28 @@ describe 'check_mk::config', type: :class do
           host_groups: host_groups,
       }
     end
-    it { should contain_class('check_mk::config') }
-    it { should contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
-    it { should contain_concat__fragment('host_groups-header').with({
+    it { is_expected.to contain_class('check_mk::config') }
+    it { is_expected.to contain_file('/omd/sites/TEST_SITE/etc/nagios/local/hostgroups').with_ensure_directory }
+    it { is_expected.to contain_concat__fragment('host_groups-header').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /host_groups = \[\n/,
           order: 20,
       })
     }
-    it { should contain_concat__fragment('host_groups-footer').with({
+    it { is_expected.to contain_concat__fragment('host_groups-footer').with({
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           content: /\]\n/,
           order: 29,
       })
     }
-    it { should contain_check_mk__hostgroup('group1').with({
+    it { is_expected.to contain_check_mk__hostgroup('group1').with({
           dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
           hostgroups: host_groups,
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',
           notify: 'Exec[check_mk-refresh]',
       })
     }
-    it { should contain_check_mk__hostgroup('group2').with({
+    it { is_expected.to contain_check_mk__hostgroup('group2').with({
           dir: '/omd/sites/TEST_SITE/etc/nagios/local/hostgroups',
           hostgroups: host_groups,
           target: '/omd/sites/TEST_SITE/etc/check_mk/main.mk',

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -65,8 +65,8 @@ describe 'check_mk::config', type: :class do
   end
   context 'with host_groups' do
     host_groups = {
-      'group1' => {'host_tags' => []},
-      'group2' => {'host_tags' => []}
+      'group1' => { 'host_tags' => [] },
+      'group2' => { 'host_tags' => [] }
     }
     let :params do
       {

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -12,8 +12,9 @@ describe 'check_mk::install', type: :class do
 
     it { is_expected.to contain_class('check_mk::install') }
     it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
-    it { is_expected.to contain_exec('omd-create-site').with(command: '/usr/bin/omd create site',
-                                                             creates: '/omd/sites/site/etc')
+    it {
+      is_expected.to contain_exec('omd-create-site').with(command: '/usr/bin/omd create site',
+                                                          creates: '/omd/sites/site/etc')
     }
   end
 end

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -6,14 +6,14 @@ describe 'check_mk::install', type: :class do
           filestore: false,
           package: 'package',
           site: 'site',
-          workspace: 'workspace',
+          workspace: 'workspace'
       }
     end
     it { is_expected.to contain_class('check_mk::install') }
     it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
     it { is_expected.to contain_exec('omd-create-site').with({
          command: '/usr/bin/omd create site',
-         creates: '/omd/sites/site/etc',
+         creates: '/omd/sites/site/etc'
       })
     }
   end

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -3,18 +3,18 @@ describe 'check_mk::install', type: :class do
   context 'with necessary parameters set' do
     let :params do
       {
-          filestore: false,
-          package: 'package',
-          site: 'site',
-          workspace: 'workspace'
+        filestore: false,
+        package: 'package',
+        site: 'site',
+        workspace: 'workspace'
       }
     end
     it { is_expected.to contain_class('check_mk::install') }
     it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
     it { is_expected.to contain_exec('omd-create-site').with({
-         command: '/usr/bin/omd create site',
-         creates: '/omd/sites/site/etc'
-      })
+                                                               command: '/usr/bin/omd create site',
+                                                               creates: '/omd/sites/site/etc'
+                                                             })
     }
   end
 end

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -12,10 +12,8 @@ describe 'check_mk::install', type: :class do
 
     it { is_expected.to contain_class('check_mk::install') }
     it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
-    it { is_expected.to contain_exec('omd-create-site').with({
-                                                               command: '/usr/bin/omd create site',
-                                                               creates: '/omd/sites/site/etc'
-                                                             })
+    it { is_expected.to contain_exec('omd-create-site').with(command: '/usr/bin/omd create site',
+                                                             creates: '/omd/sites/site/etc')
     }
   end
 end

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -9,6 +9,7 @@ describe 'check_mk::install', type: :class do
         workspace: 'workspace'
       }
     end
+
     it { is_expected.to contain_class('check_mk::install') }
     it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
     it { is_expected.to contain_exec('omd-create-site').with({

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper'
-describe 'check_mk::install', :type => :class do
+describe 'check_mk::install', type: :class do
   context 'with necessary parameters set' do
     let :params do
       {
-          :filestore => false,
-          :package => 'package',
-          :site => 'site',
-          :workspace => 'workspace',
+          filestore: false,
+          package: 'package',
+          site: 'site',
+          workspace: 'workspace',
       }
     end
     it { should contain_class('check_mk::install') }
     it { should contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
     it { should contain_exec('omd-create-site').with({
-         :command => '/usr/bin/omd create site',
-         :creates => '/omd/sites/site/etc',
+         command: '/usr/bin/omd create site',
+         creates: '/omd/sites/site/etc',
       })
     }
   end

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -9,9 +9,9 @@ describe 'check_mk::install', type: :class do
           workspace: 'workspace',
       }
     end
-    it { should contain_class('check_mk::install') }
-    it { should contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
-    it { should contain_exec('omd-create-site').with({
+    it { is_expected.to contain_class('check_mk::install') }
+    it { is_expected.to contain_package('package').with_ensure('installed').that_comes_before('Exec[omd-create-site]') }
+    it { is_expected.to contain_exec('omd-create-site').with({
          command: '/usr/bin/omd create site',
          creates: '/omd/sites/site/etc',
       })

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -8,7 +8,7 @@ describe 'check_mk::install_tarball', type: :class do
       {
           filestore: '/filestore',
           version: '1.2.3',
-          workspace: '/workspace',
+          workspace: '/workspace'
       }
     end
     it { is_expected.to contain_class('check_mk::install_tarball') }
@@ -28,45 +28,45 @@ describe 'check_mk::install_tarball', type: :class do
           ensure: 'present',
           owner: 'root',
           group: 'apache',
-          mode: '0640',
+          mode: '0640'
       })
     }
     it { is_expected.to contain_exec('set-nagiosadmin-password').with({
           refreshonly: true,
-          require: 'File[/etc/nagios/passwd]',
+          require: 'File[/etc/nagios/passwd]'
       })
     }
     it { is_expected.to contain_exec('set-guest-password').with({
           refreshonly: true,
-          require: 'File[/etc/nagios/passwd]',
+          require: 'File[/etc/nagios/passwd]'
       })
     }
     it { is_expected.to contain_exec('add-apache-to-nagios-group').with({
-          refreshonly: true,
+          refreshonly: true
       })
     }
     it { is_expected.to contain_package('nagios-plugins-all').with({
           ensure: 'present',
-          require: 'Package[nagios]',
+          require: 'Package[nagios]'
       })
     }
     it { is_expected.to contain_exec('unpack-check_mk-tarball').with({
           command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
           cwd: '/workspace',
           creates: '/workspace/check_mk-1.2.3',
-          require: 'File[/workspace/check_mk-1.2.3.tar.gz]',
+          require: 'File[/workspace/check_mk-1.2.3.tar.gz]'
       })
     }
     it { is_expected.to contain_exec('change-setup-config-location').with({
           command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
           unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
-          require: 'Exec[unpack-check_mk-tarball]',
+          require: 'Exec[unpack-check_mk-tarball]'
       })
     }
     it { is_expected.to contain_exec('remove-setup-header').with({
           command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
           unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
-          require: 'Exec[unpack-check_mk-tarball]',
+          require: 'Exec[unpack-check_mk-tarball]'
       })
     }
     it { is_expected.to contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
@@ -75,14 +75,14 @@ describe 'check_mk::install_tarball', type: :class do
           owner: 'nagios',
           group: 'nagios',
           recurse: true,
-          require: 'Package[nagios]',
+          require: 'Package[nagios]'
       })
     }
     it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with({
           ensure: 'directory',
           owner: 'nagios',
           group: 'nagios',
-          require: 'File[/etc/nagios/check_mk]',
+          require: 'File[/etc/nagios/check_mk]'
       })
     }
     it { is_expected.to contain_exec('check_mk-setup').with({
@@ -95,9 +95,9 @@ describe 'check_mk::install_tarball', type: :class do
                'Exec[unpack-check_mk-tarball]',
                'File[/workspace/check_mk_setup.conf]',
                'File[/etc/nagios/check_mk]',
-               'Package[nagios]',
+               'Package[nagios]'
            ],
-           notify: 'Class[Check_mk::Service]',
+           notify: 'Class[Check_mk::Service]'
        })
     }
 

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -101,6 +101,5 @@ describe 'check_mk::install_tarball', type: :class do
                                                               notify: 'Class[Check_mk::Service]'
                                                             })
     }
-
   end
 end

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -14,12 +14,12 @@ describe 'check_mk::install_tarball', type: :class do
     it { is_expected.to contain_class('check_mk::install_tarball') }
     it { is_expected.to contain_package('nagios').with_ensure('present').that_comes_before('Package[nagios-plugins-all]') }
     installed_packages = [
-        'xinetd',
-        'mod_python',
-        'make',
-        'gcc-c++',
-        'tar',
-        'gzip'
+      'xinetd',
+      'mod_python',
+      'make',
+      'gcc-c++',
+      'tar',
+      'gzip'
     ]
     installed_packages.each do |package|
       it { is_expected.to contain_package(package).with_ensure('present') }
@@ -90,12 +90,12 @@ describe 'check_mk::install_tarball', type: :class do
            cwd: '/workspace/check_mk-1.2.3',
            refreshonly: true,
            require: [
-               'Exec[change-setup-config-location]',
-               'Exec[remove-setup-header]',
-               'Exec[unpack-check_mk-tarball]',
-               'File[/workspace/check_mk_setup.conf]',
-               'File[/etc/nagios/check_mk]',
-               'Package[nagios]'
+             'Exec[change-setup-config-location]',
+             'Exec[remove-setup-header]',
+             'Exec[unpack-check_mk-tarball]',
+             'File[/workspace/check_mk_setup.conf]',
+             'File[/etc/nagios/check_mk]',
+             'Package[nagios]'
            ],
            notify: 'Class[Check_mk::Service]'
        })

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -11,6 +11,7 @@ describe 'check_mk::install_tarball', type: :class do
         workspace: '/workspace'
       }
     end
+
     it { is_expected.to contain_class('check_mk::install_tarball') }
     it { is_expected.to contain_package('nagios').with_ensure('present').that_comes_before('Package[nagios-plugins-all]') }
     installed_packages = [

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -11,8 +11,8 @@ describe 'check_mk::install_tarball', type: :class do
           workspace: '/workspace',
       }
     end
-    it { should contain_class('check_mk::install_tarball') }
-    it { should contain_package('nagios').with_ensure('present').that_comes_before('Package[nagios-plugins-all]') }
+    it { is_expected.to contain_class('check_mk::install_tarball') }
+    it { is_expected.to contain_package('nagios').with_ensure('present').that_comes_before('Package[nagios-plugins-all]') }
     installed_packages = [
         'xinetd',
         'mod_python',
@@ -22,55 +22,55 @@ describe 'check_mk::install_tarball', type: :class do
         'gzip'
     ]
     installed_packages.each do |package|
-      it { should contain_package(package).with_ensure('present') }
+      it { is_expected.to contain_package(package).with_ensure('present') }
     end
-    it { should contain_file('/etc/nagios/passwd').with({
+    it { is_expected.to contain_file('/etc/nagios/passwd').with({
           ensure: 'present',
           owner: 'root',
           group: 'apache',
           mode: '0640',
       })
     }
-    it { should contain_exec('set-nagiosadmin-password').with({
+    it { is_expected.to contain_exec('set-nagiosadmin-password').with({
           refreshonly: true,
           require: 'File[/etc/nagios/passwd]',
       })
     }
-    it { should contain_exec('set-guest-password').with({
+    it { is_expected.to contain_exec('set-guest-password').with({
           refreshonly: true,
           require: 'File[/etc/nagios/passwd]',
       })
     }
-    it { should contain_exec('add-apache-to-nagios-group').with({
+    it { is_expected.to contain_exec('add-apache-to-nagios-group').with({
           refreshonly: true,
       })
     }
-    it { should contain_package('nagios-plugins-all').with({
+    it { is_expected.to contain_package('nagios-plugins-all').with({
           ensure: 'present',
           require: 'Package[nagios]',
       })
     }
-    it { should contain_exec('unpack-check_mk-tarball').with({
+    it { is_expected.to contain_exec('unpack-check_mk-tarball').with({
           command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
           cwd: '/workspace',
           creates: '/workspace/check_mk-1.2.3',
           require: 'File[/workspace/check_mk-1.2.3.tar.gz]',
       })
     }
-    it { should contain_exec('change-setup-config-location').with({
+    it { is_expected.to contain_exec('change-setup-config-location').with({
           command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
           unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
           require: 'Exec[unpack-check_mk-tarball]',
       })
     }
-    it { should contain_exec('remove-setup-header').with({
+    it { is_expected.to contain_exec('remove-setup-header').with({
           command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
           unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
           require: 'Exec[unpack-check_mk-tarball]',
       })
     }
-    it { should contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
-    it { should contain_file('/etc/nagios/check_mk').with({
+    it { is_expected.to contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
+    it { is_expected.to contain_file('/etc/nagios/check_mk').with({
           ensure: 'directory',
           owner: 'nagios',
           group: 'nagios',
@@ -78,14 +78,14 @@ describe 'check_mk::install_tarball', type: :class do
           require: 'Package[nagios]',
       })
     }
-    it { should contain_file('/etc/nagios/check_mk/hostgroups').with({
+    it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with({
           ensure: 'directory',
           owner: 'nagios',
           group: 'nagios',
           require: 'File[/etc/nagios/check_mk]',
       })
     }
-    it { should contain_exec('check_mk-setup').with({
+    it { is_expected.to contain_exec('check_mk-setup').with({
            command: '/workspace/check_mk-1.2.3/setup.sh --yes',
            cwd: '/workspace/check_mk-1.2.3',
            refreshonly: true,

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
-describe 'check_mk::install_tarball', :type => :class do
+describe 'check_mk::install_tarball', type: :class do
   # Mock check_mk::service class.
   let(:pre_condition) { "class check_mk::service{}\n include check_mk::service" }
 
   context 'with necessary parameters set' do
     let :params do
       {
-          :filestore => '/filestore',
-          :version   => '1.2.3',
-          :workspace => '/workspace',
+          filestore: '/filestore',
+          version: '1.2.3',
+          workspace: '/workspace',
       }
     end
     it { should contain_class('check_mk::install_tarball') }
@@ -25,71 +25,71 @@ describe 'check_mk::install_tarball', :type => :class do
       it { should contain_package(package).with_ensure('present') }
     end
     it { should contain_file('/etc/nagios/passwd').with({
-          :ensure => 'present',
-          :owner  => 'root',
-          :group  => 'apache',
-          :mode   => '0640',
+          ensure: 'present',
+          owner: 'root',
+          group: 'apache',
+          mode: '0640',
       })
     }
     it { should contain_exec('set-nagiosadmin-password').with({
-          :refreshonly => true,
-          :require     => 'File[/etc/nagios/passwd]',
+          refreshonly: true,
+          require: 'File[/etc/nagios/passwd]',
       })
     }
     it { should contain_exec('set-guest-password').with({
-          :refreshonly => true,
-          :require     => 'File[/etc/nagios/passwd]',
+          refreshonly: true,
+          require: 'File[/etc/nagios/passwd]',
       })
     }
     it { should contain_exec('add-apache-to-nagios-group').with({
-          :refreshonly => true,
+          refreshonly: true,
       })
     }
     it { should contain_package('nagios-plugins-all').with({
-          :ensure  => 'present',
-          :require => 'Package[nagios]',
+          ensure: 'present',
+          require: 'Package[nagios]',
       })
     }
     it { should contain_exec('unpack-check_mk-tarball').with({
-          :command => '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
-          :cwd     => '/workspace',
-          :creates => '/workspace/check_mk-1.2.3',
-          :require => 'File[/workspace/check_mk-1.2.3.tar.gz]',
+          command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
+          cwd: '/workspace',
+          creates: '/workspace/check_mk-1.2.3',
+          require: 'File[/workspace/check_mk-1.2.3.tar.gz]',
       })
     }
     it { should contain_exec('change-setup-config-location').with({
-          :command => "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
-          :unless  => "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
-          :require => 'Exec[unpack-check_mk-tarball]',
+          command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
+          unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
+          require: 'Exec[unpack-check_mk-tarball]',
       })
     }
     it { should contain_exec('remove-setup-header').with({
-          :command => "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
-          :unless  => "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
-          :require => 'Exec[unpack-check_mk-tarball]',
+          command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
+          unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
+          require: 'Exec[unpack-check_mk-tarball]',
       })
     }
     it { should contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
     it { should contain_file('/etc/nagios/check_mk').with({
-          :ensure  => 'directory',
-          :owner   => 'nagios',
-          :group   => 'nagios',
-          :recurse => true,
-          :require => 'Package[nagios]',
+          ensure: 'directory',
+          owner: 'nagios',
+          group: 'nagios',
+          recurse: true,
+          require: 'Package[nagios]',
       })
     }
     it { should contain_file('/etc/nagios/check_mk/hostgroups').with({
-          :ensure  => 'directory',
-          :owner   => 'nagios',
-          :group   => 'nagios',
-          :require => 'File[/etc/nagios/check_mk]',
+          ensure: 'directory',
+          owner: 'nagios',
+          group: 'nagios',
+          require: 'File[/etc/nagios/check_mk]',
       })
     }
     it { should contain_exec('check_mk-setup').with({
-           :command     => '/workspace/check_mk-1.2.3/setup.sh --yes',
-           :cwd         => '/workspace/check_mk-1.2.3',
-           :refreshonly => true,
-           :require => [
+           command: '/workspace/check_mk-1.2.3/setup.sh --yes',
+           cwd: '/workspace/check_mk-1.2.3',
+           refreshonly: true,
+           require: [
                'Exec[change-setup-config-location]',
                'Exec[remove-setup-header]',
                'Exec[unpack-check_mk-tarball]',
@@ -97,7 +97,7 @@ describe 'check_mk::install_tarball', :type => :class do
                'File[/etc/nagios/check_mk]',
                'Package[nagios]',
            ],
-           :notify      => 'Class[Check_mk::Service]',
+           notify: 'Class[Check_mk::Service]',
        })
     }
 

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -25,81 +25,59 @@ describe 'check_mk::install_tarball', type: :class do
     installed_packages.each do |package|
       it { is_expected.to contain_package(package).with_ensure('present') }
     end
-    it { is_expected.to contain_file('/etc/nagios/passwd').with({
-                                                                  ensure: 'present',
-                                                                  owner: 'root',
-                                                                  group: 'apache',
-                                                                  mode: '0640'
-                                                                })
+    it { is_expected.to contain_file('/etc/nagios/passwd').with(ensure: 'present',
+                                                                owner: 'root',
+                                                                group: 'apache',
+                                                                mode: '0640')
     }
-    it { is_expected.to contain_exec('set-nagiosadmin-password').with({
-                                                                        refreshonly: true,
-                                                                        require: 'File[/etc/nagios/passwd]'
-                                                                      })
+    it { is_expected.to contain_exec('set-nagiosadmin-password').with(refreshonly: true,
+                                                                      require: 'File[/etc/nagios/passwd]')
     }
-    it { is_expected.to contain_exec('set-guest-password').with({
-                                                                  refreshonly: true,
-                                                                  require: 'File[/etc/nagios/passwd]'
-                                                                })
+    it { is_expected.to contain_exec('set-guest-password').with(refreshonly: true,
+                                                                require: 'File[/etc/nagios/passwd]')
     }
-    it { is_expected.to contain_exec('add-apache-to-nagios-group').with({
-                                                                          refreshonly: true
-                                                                        })
+    it { is_expected.to contain_exec('add-apache-to-nagios-group').with(refreshonly: true)
     }
-    it { is_expected.to contain_package('nagios-plugins-all').with({
-                                                                     ensure: 'present',
-                                                                     require: 'Package[nagios]'
-                                                                   })
+    it { is_expected.to contain_package('nagios-plugins-all').with(ensure: 'present',
+                                                                   require: 'Package[nagios]')
     }
-    it { is_expected.to contain_exec('unpack-check_mk-tarball').with({
-                                                                       command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
-                                                                       cwd: '/workspace',
-                                                                       creates: '/workspace/check_mk-1.2.3',
-                                                                       require: 'File[/workspace/check_mk-1.2.3.tar.gz]'
-                                                                     })
+    it { is_expected.to contain_exec('unpack-check_mk-tarball').with(command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
+                                                                     cwd: '/workspace',
+                                                                     creates: '/workspace/check_mk-1.2.3',
+                                                                     require: 'File[/workspace/check_mk-1.2.3.tar.gz]')
     }
-    it { is_expected.to contain_exec('change-setup-config-location').with({
-                                                                            command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
-                                                                            unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
-                                                                            require: 'Exec[unpack-check_mk-tarball]'
-                                                                          })
+    it { is_expected.to contain_exec('change-setup-config-location').with(command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
+                                                                          unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
+                                                                          require: 'Exec[unpack-check_mk-tarball]')
     }
-    it { is_expected.to contain_exec('remove-setup-header').with({
-                                                                   command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
-                                                                   unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
-                                                                   require: 'Exec[unpack-check_mk-tarball]'
-                                                                 })
+    it { is_expected.to contain_exec('remove-setup-header').with(command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
+                                                                 unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
+                                                                 require: 'Exec[unpack-check_mk-tarball]')
     }
     it { is_expected.to contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
-    it { is_expected.to contain_file('/etc/nagios/check_mk').with({
-                                                                    ensure: 'directory',
-                                                                    owner: 'nagios',
-                                                                    group: 'nagios',
-                                                                    recurse: true,
-                                                                    require: 'Package[nagios]'
-                                                                  })
+    it { is_expected.to contain_file('/etc/nagios/check_mk').with(ensure: 'directory',
+                                                                  owner: 'nagios',
+                                                                  group: 'nagios',
+                                                                  recurse: true,
+                                                                  require: 'Package[nagios]')
     }
-    it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with({
-                                                                               ensure: 'directory',
-                                                                               owner: 'nagios',
-                                                                               group: 'nagios',
-                                                                               require: 'File[/etc/nagios/check_mk]'
-                                                                             })
+    it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with(ensure: 'directory',
+                                                                             owner: 'nagios',
+                                                                             group: 'nagios',
+                                                                             require: 'File[/etc/nagios/check_mk]')
     }
-    it { is_expected.to contain_exec('check_mk-setup').with({
-                                                              command: '/workspace/check_mk-1.2.3/setup.sh --yes',
-                                                              cwd: '/workspace/check_mk-1.2.3',
-                                                              refreshonly: true,
-                                                              require: [
-                                                                'Exec[change-setup-config-location]',
-                                                                'Exec[remove-setup-header]',
-                                                                'Exec[unpack-check_mk-tarball]',
-                                                                'File[/workspace/check_mk_setup.conf]',
-                                                                'File[/etc/nagios/check_mk]',
-                                                                'Package[nagios]'
-                                                              ],
-                                                              notify: 'Class[Check_mk::Service]'
-                                                            })
+    it { is_expected.to contain_exec('check_mk-setup').with(command: '/workspace/check_mk-1.2.3/setup.sh --yes',
+                                                            cwd: '/workspace/check_mk-1.2.3',
+                                                            refreshonly: true,
+                                                            require: [
+                                                              'Exec[change-setup-config-location]',
+                                                              'Exec[remove-setup-header]',
+                                                              'Exec[unpack-check_mk-tarball]',
+                                                              'File[/workspace/check_mk_setup.conf]',
+                                                              'File[/etc/nagios/check_mk]',
+                                                              'Package[nagios]'
+                                                            ],
+                                                            notify: 'Class[Check_mk::Service]')
     }
   end
 end

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -6,9 +6,9 @@ describe 'check_mk::install_tarball', type: :class do
   context 'with necessary parameters set' do
     let :params do
       {
-          filestore: '/filestore',
-          version: '1.2.3',
-          workspace: '/workspace'
+        filestore: '/filestore',
+        version: '1.2.3',
+        workspace: '/workspace'
       }
     end
     it { is_expected.to contain_class('check_mk::install_tarball') }
@@ -25,80 +25,80 @@ describe 'check_mk::install_tarball', type: :class do
       it { is_expected.to contain_package(package).with_ensure('present') }
     end
     it { is_expected.to contain_file('/etc/nagios/passwd').with({
-          ensure: 'present',
-          owner: 'root',
-          group: 'apache',
-          mode: '0640'
-      })
+                                                                  ensure: 'present',
+                                                                  owner: 'root',
+                                                                  group: 'apache',
+                                                                  mode: '0640'
+                                                                })
     }
     it { is_expected.to contain_exec('set-nagiosadmin-password').with({
-          refreshonly: true,
-          require: 'File[/etc/nagios/passwd]'
-      })
+                                                                        refreshonly: true,
+                                                                        require: 'File[/etc/nagios/passwd]'
+                                                                      })
     }
     it { is_expected.to contain_exec('set-guest-password').with({
-          refreshonly: true,
-          require: 'File[/etc/nagios/passwd]'
-      })
+                                                                  refreshonly: true,
+                                                                  require: 'File[/etc/nagios/passwd]'
+                                                                })
     }
     it { is_expected.to contain_exec('add-apache-to-nagios-group').with({
-          refreshonly: true
-      })
+                                                                          refreshonly: true
+                                                                        })
     }
     it { is_expected.to contain_package('nagios-plugins-all').with({
-          ensure: 'present',
-          require: 'Package[nagios]'
-      })
+                                                                     ensure: 'present',
+                                                                     require: 'Package[nagios]'
+                                                                   })
     }
     it { is_expected.to contain_exec('unpack-check_mk-tarball').with({
-          command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
-          cwd: '/workspace',
-          creates: '/workspace/check_mk-1.2.3',
-          require: 'File[/workspace/check_mk-1.2.3.tar.gz]'
-      })
+                                                                       command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
+                                                                       cwd: '/workspace',
+                                                                       creates: '/workspace/check_mk-1.2.3',
+                                                                       require: 'File[/workspace/check_mk-1.2.3.tar.gz]'
+                                                                     })
     }
     it { is_expected.to contain_exec('change-setup-config-location').with({
-          command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
-          unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
-          require: 'Exec[unpack-check_mk-tarball]'
-      })
+                                                                            command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
+                                                                            unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
+                                                                            require: 'Exec[unpack-check_mk-tarball]'
+                                                                          })
     }
     it { is_expected.to contain_exec('remove-setup-header').with({
-          command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
-          unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
-          require: 'Exec[unpack-check_mk-tarball]'
-      })
+                                                                   command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
+                                                                   unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
+                                                                   require: 'Exec[unpack-check_mk-tarball]'
+                                                                 })
     }
     it { is_expected.to contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
     it { is_expected.to contain_file('/etc/nagios/check_mk').with({
-          ensure: 'directory',
-          owner: 'nagios',
-          group: 'nagios',
-          recurse: true,
-          require: 'Package[nagios]'
-      })
+                                                                    ensure: 'directory',
+                                                                    owner: 'nagios',
+                                                                    group: 'nagios',
+                                                                    recurse: true,
+                                                                    require: 'Package[nagios]'
+                                                                  })
     }
     it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with({
-          ensure: 'directory',
-          owner: 'nagios',
-          group: 'nagios',
-          require: 'File[/etc/nagios/check_mk]'
-      })
+                                                                               ensure: 'directory',
+                                                                               owner: 'nagios',
+                                                                               group: 'nagios',
+                                                                               require: 'File[/etc/nagios/check_mk]'
+                                                                             })
     }
     it { is_expected.to contain_exec('check_mk-setup').with({
-           command: '/workspace/check_mk-1.2.3/setup.sh --yes',
-           cwd: '/workspace/check_mk-1.2.3',
-           refreshonly: true,
-           require: [
-             'Exec[change-setup-config-location]',
-             'Exec[remove-setup-header]',
-             'Exec[unpack-check_mk-tarball]',
-             'File[/workspace/check_mk_setup.conf]',
-             'File[/etc/nagios/check_mk]',
-             'Package[nagios]'
-           ],
-           notify: 'Class[Check_mk::Service]'
-       })
+                                                              command: '/workspace/check_mk-1.2.3/setup.sh --yes',
+                                                              cwd: '/workspace/check_mk-1.2.3',
+                                                              refreshonly: true,
+                                                              require: [
+                                                                'Exec[change-setup-config-location]',
+                                                                'Exec[remove-setup-header]',
+                                                                'Exec[unpack-check_mk-tarball]',
+                                                                'File[/workspace/check_mk_setup.conf]',
+                                                                'File[/etc/nagios/check_mk]',
+                                                                'Package[nagios]'
+                                                              ],
+                                                              notify: 'Class[Check_mk::Service]'
+                                                            })
     }
 
   end

--- a/spec/classes/check_mk_install_tarball_spec.rb
+++ b/spec/classes/check_mk_install_tarball_spec.rb
@@ -25,59 +25,70 @@ describe 'check_mk::install_tarball', type: :class do
     installed_packages.each do |package|
       it { is_expected.to contain_package(package).with_ensure('present') }
     end
-    it { is_expected.to contain_file('/etc/nagios/passwd').with(ensure: 'present',
-                                                                owner: 'root',
-                                                                group: 'apache',
-                                                                mode: '0640')
+    it {
+      is_expected.to contain_file('/etc/nagios/passwd').with(ensure: 'present',
+                                                             owner: 'root',
+                                                             group: 'apache',
+                                                             mode: '0640')
     }
-    it { is_expected.to contain_exec('set-nagiosadmin-password').with(refreshonly: true,
-                                                                      require: 'File[/etc/nagios/passwd]')
+    it {
+      is_expected.to contain_exec('set-nagiosadmin-password').with(refreshonly: true,
+                                                                   require: 'File[/etc/nagios/passwd]')
     }
-    it { is_expected.to contain_exec('set-guest-password').with(refreshonly: true,
-                                                                require: 'File[/etc/nagios/passwd]')
+    it {
+      is_expected.to contain_exec('set-guest-password').with(refreshonly: true,
+                                                             require: 'File[/etc/nagios/passwd]')
     }
-    it { is_expected.to contain_exec('add-apache-to-nagios-group').with(refreshonly: true)
+    it {
+      is_expected.to contain_exec('add-apache-to-nagios-group').with(refreshonly: true)
     }
-    it { is_expected.to contain_package('nagios-plugins-all').with(ensure: 'present',
-                                                                   require: 'Package[nagios]')
+    it {
+      is_expected.to contain_package('nagios-plugins-all').with(ensure: 'present',
+                                                                require: 'Package[nagios]')
     }
-    it { is_expected.to contain_exec('unpack-check_mk-tarball').with(command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
-                                                                     cwd: '/workspace',
-                                                                     creates: '/workspace/check_mk-1.2.3',
-                                                                     require: 'File[/workspace/check_mk-1.2.3.tar.gz]')
+    it {
+      is_expected.to contain_exec('unpack-check_mk-tarball').with(command: '/bin/tar -zxf /workspace/check_mk-1.2.3.tar.gz',
+                                                                  cwd: '/workspace',
+                                                                  creates: '/workspace/check_mk-1.2.3',
+                                                                  require: 'File[/workspace/check_mk-1.2.3.tar.gz]')
     }
-    it { is_expected.to contain_exec('change-setup-config-location').with(command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
-                                                                          unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
-                                                                          require: 'Exec[unpack-check_mk-tarball]')
+    it {
+      is_expected.to contain_exec('change-setup-config-location').with(command: "/usr/bin/perl -pi -e 's#^SETUPCONF=.*?$#SETUPCONF=/workspace/check_mk_setup.conf#' /workspace/check_mk-1.2.3/setup.sh",
+                                                                       unless: "/bin/egrep '^SETUPCONF=/workspace/check_mk_setup.conf$' /workspace/check_mk-1.2.3/setup.sh",
+                                                                       require: 'Exec[unpack-check_mk-tarball]')
     }
-    it { is_expected.to contain_exec('remove-setup-header').with(command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
-                                                                 unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
-                                                                 require: 'Exec[unpack-check_mk-tarball]')
+    it {
+      is_expected.to contain_exec('remove-setup-header').with(command: "/usr/bin/perl -pi -e 's#^DIRINFO=.*?$#DIRINFO=#' /workspace/check_mk-1.2.3/setup.sh",
+                                                              unless: "/bin/egrep '^DIRINFO=$' /workspace/check_mk-1.2.3/setup.sh",
+                                                              require: 'Exec[unpack-check_mk-tarball]')
     }
     it { is_expected.to contain_file('/workspace/check_mk_setup.conf').that_notifies('Exec[check_mk-setup]') }
-    it { is_expected.to contain_file('/etc/nagios/check_mk').with(ensure: 'directory',
-                                                                  owner: 'nagios',
-                                                                  group: 'nagios',
-                                                                  recurse: true,
-                                                                  require: 'Package[nagios]')
+    it {
+      is_expected.to contain_file('/etc/nagios/check_mk').with(ensure: 'directory',
+                                                               owner: 'nagios',
+                                                               group: 'nagios',
+                                                               recurse: true,
+                                                               require: 'Package[nagios]')
     }
-    it { is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with(ensure: 'directory',
-                                                                             owner: 'nagios',
-                                                                             group: 'nagios',
-                                                                             require: 'File[/etc/nagios/check_mk]')
+    it {
+      is_expected.to contain_file('/etc/nagios/check_mk/hostgroups').with(ensure: 'directory',
+                                                                          owner: 'nagios',
+                                                                          group: 'nagios',
+                                                                          require: 'File[/etc/nagios/check_mk]')
     }
-    it { is_expected.to contain_exec('check_mk-setup').with(command: '/workspace/check_mk-1.2.3/setup.sh --yes',
-                                                            cwd: '/workspace/check_mk-1.2.3',
-                                                            refreshonly: true,
-                                                            require: [
-                                                              'Exec[change-setup-config-location]',
-                                                              'Exec[remove-setup-header]',
-                                                              'Exec[unpack-check_mk-tarball]',
-                                                              'File[/workspace/check_mk_setup.conf]',
-                                                              'File[/etc/nagios/check_mk]',
-                                                              'Package[nagios]'
-                                                            ],
-                                                            notify: 'Class[Check_mk::Service]')
+    it {
+      is_expected.to contain_exec('check_mk-setup').with(command: '/workspace/check_mk-1.2.3/setup.sh --yes',
+                                                         cwd: '/workspace/check_mk-1.2.3',
+                                                         refreshonly: true,
+                                                         require: [
+                                                           'Exec[change-setup-config-location]',
+                                                           'Exec[remove-setup-header]',
+                                                           'Exec[unpack-check_mk-tarball]',
+                                                           'File[/workspace/check_mk_setup.conf]',
+                                                           'File[/etc/nagios/check_mk]',
+                                                           'Package[nagios]'
+                                                         ],
+                                                         notify: 'Class[Check_mk::Service]')
     }
   end
 end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -19,12 +19,12 @@ describe 'check_mk::service' do
         it { is_expected.to contain_class('check_mk::service') }
         it { is_expected.to contain_service(service_name).with({
           ensure: 'running',
-          enable: 'true',
+          enable: 'true'
         })
         }
         it { is_expected.to contain_service('omd').with({
           ensure: 'running',
-          enable: 'true',
+          enable: 'true'
         })
         }
       end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -16,13 +16,13 @@ describe 'check_mk::service' do
       end
 
       context 'with defaults for all parameters' do
-        it { should contain_class('check_mk::service') }
-        it { should contain_service(service_name).with({
+        it { is_expected.to contain_class('check_mk::service') }
+        it { is_expected.to contain_service(service_name).with({
           ensure: 'running',
           enable: 'true',
         })
         }
-        it { should contain_service('omd').with({
+        it { is_expected.to contain_service('omd').with({
           ensure: 'running',
           enable: 'true',
         })

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -16,11 +16,13 @@ describe 'check_mk::service' do
 
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk::service') }
-        it { is_expected.to contain_service(service_name).with(ensure: 'running',
-                                                               enable: 'true')
+        it {
+          is_expected.to contain_service(service_name).with(ensure: 'running',
+                                                            enable: 'true')
         }
-        it { is_expected.to contain_service('omd').with(ensure: 'running',
-                                                        enable: 'true')
+        it {
+          is_expected.to contain_service('omd').with(ensure: 'running',
+                                                     enable: 'true')
         }
       end
     end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -16,15 +16,11 @@ describe 'check_mk::service' do
 
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk::service') }
-        it { is_expected.to contain_service(service_name).with({
-                                                                 ensure: 'running',
-                                                                 enable: 'true'
-                                                               })
+        it { is_expected.to contain_service(service_name).with(ensure: 'running',
+                                                               enable: 'true')
         }
-        it { is_expected.to contain_service('omd').with({
-                                                          ensure: 'running',
-                                                          enable: 'true'
-                                                        })
+        it { is_expected.to contain_service('omd').with(ensure: 'running',
+                                                        enable: 'true')
         }
       end
     end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -7,12 +7,12 @@ describe 'check_mk::service' do
       end
       let(:pre_condition) { 'include check_mk' }
 
-      case facts[:osfamily]
-      when 'Debian'
-        service_name = 'apache2'
-      else
-        service_name = 'httpd'
-      end
+      service_name = case facts[:osfamily]
+                     when 'Debian'
+                       'apache2'
+                     else
+                       'httpd'
+                     end
 
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk::service') }

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -18,14 +18,14 @@ describe 'check_mk::service' do
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk::service') }
         it { is_expected.to contain_service(service_name).with({
-          ensure: 'running',
-          enable: 'true'
-        })
+                                                                 ensure: 'running',
+                                                                 enable: 'true'
+                                                               })
         }
         it { is_expected.to contain_service('omd').with({
-          ensure: 'running',
-          enable: 'true'
-        })
+                                                          ensure: 'running',
+                                                          enable: 'true'
+                                                        })
         }
       end
     end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -18,13 +18,13 @@ describe 'check_mk::service' do
       context 'with defaults for all parameters' do
         it { should contain_class('check_mk::service') }
         it { should contain_service(service_name).with({
-          :ensure => 'running',
-          :enable => 'true',
+          ensure: 'running',
+          enable: 'true',
         })
         }
         it { should contain_service('omd').with({
-          :ensure => 'running',
-          :enable => 'true',
+          ensure: 'running',
+          enable: 'true',
         })
         }
       end

--- a/spec/classes/check_mk_service_spec.rb
+++ b/spec/classes/check_mk_service_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 describe 'check_mk::service' do
-
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -7,18 +7,18 @@ describe 'check_mk' do
       end
 
       context 'with defaults for all parameters' do
-        it { should contain_class('check_mk') }
-        it { should contain_class('check_mk::install').with({
+        it { is_expected.to contain_class('check_mk') }
+        it { is_expected.to contain_class('check_mk::install').with({
           filestore: nil,
           package: 'omd-0.56',
           site: 'monitoring',
           workspace: '/root/check_mk',
         }).that_comes_before('Class[check_mk::config]') }
-        it { should contain_class('check_mk::config').with({
+        it { is_expected.to contain_class('check_mk::config').with({
           host_groups: nil,
           site: 'monitoring',
         }).that_comes_before('Class[check_mk::service]') }
-        it { should contain_class('check_mk::service') }
+        it { is_expected.to contain_class('check_mk::service') }
       end
     end
   end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -8,13 +8,15 @@ describe 'check_mk' do
 
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk') }
-        it { is_expected.to contain_class('check_mk::install').with(filestore: nil,
-                                                                    package: 'omd-0.56',
-                                                                    site: 'monitoring',
-                                                                    workspace: '/root/check_mk').that_comes_before('Class[check_mk::config]')
+        it {
+          is_expected.to contain_class('check_mk::install').with(filestore: nil,
+                                                                 package: 'omd-0.56',
+                                                                 site: 'monitoring',
+                                                                 workspace: '/root/check_mk').that_comes_before('Class[check_mk::config]')
         }
-        it { is_expected.to contain_class('check_mk::config').with(host_groups: nil,
-                                                                   site: 'monitoring').that_comes_before('Class[check_mk::service]')
+        it {
+          is_expected.to contain_class('check_mk::config').with(host_groups: nil,
+                                                                site: 'monitoring').that_comes_before('Class[check_mk::service]')
         }
         it { is_expected.to contain_class('check_mk::service') }
       end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -12,11 +12,11 @@ describe 'check_mk' do
           filestore: nil,
           package: 'omd-0.56',
           site: 'monitoring',
-          workspace: '/root/check_mk',
+          workspace: '/root/check_mk'
         }).that_comes_before('Class[check_mk::config]') }
         it { is_expected.to contain_class('check_mk::config').with({
           host_groups: nil,
-          site: 'monitoring',
+          site: 'monitoring'
         }).that_comes_before('Class[check_mk::service]') }
         it { is_expected.to contain_class('check_mk::service') }
       end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -9,15 +9,15 @@ describe 'check_mk' do
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk') }
         it { is_expected.to contain_class('check_mk::install').with({
-          filestore: nil,
-          package: 'omd-0.56',
-          site: 'monitoring',
-          workspace: '/root/check_mk'
-        }).that_comes_before('Class[check_mk::config]') }
+                                                                      filestore: nil,
+                                                                      package: 'omd-0.56',
+                                                                      site: 'monitoring',
+                                                                      workspace: '/root/check_mk'
+                                                                    }).that_comes_before('Class[check_mk::config]') }
         it { is_expected.to contain_class('check_mk::config').with({
-          host_groups: nil,
-          site: 'monitoring'
-        }).that_comes_before('Class[check_mk::service]') }
+                                                                     host_groups: nil,
+                                                                     site: 'monitoring'
+                                                                   }).that_comes_before('Class[check_mk::service]') }
         it { is_expected.to contain_class('check_mk::service') }
       end
     end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -9,14 +9,14 @@ describe 'check_mk' do
       context 'with defaults for all parameters' do
         it { should contain_class('check_mk') }
         it { should contain_class('check_mk::install').with({
-          :filestore => nil,
-          :package   => 'omd-0.56',
-          :site      => 'monitoring',
-          :workspace => '/root/check_mk',
+          filestore: nil,
+          package: 'omd-0.56',
+          site: 'monitoring',
+          workspace: '/root/check_mk',
         }).that_comes_before('Class[check_mk::config]') }
         it { should contain_class('check_mk::config').with({
-          :host_groups => nil,
-          :site        => 'monitoring',
+          host_groups: nil,
+          site: 'monitoring',
         }).that_comes_before('Class[check_mk::service]') }
         it { should contain_class('check_mk::service') }
       end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -8,16 +8,14 @@ describe 'check_mk' do
 
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('check_mk') }
-        it { is_expected.to contain_class('check_mk::install').with({
-                                                                      filestore: nil,
-                                                                      package: 'omd-0.56',
-                                                                      site: 'monitoring',
-                                                                      workspace: '/root/check_mk'
-                                                                    }).that_comes_before('Class[check_mk::config]') }
-        it { is_expected.to contain_class('check_mk::config').with({
-                                                                     host_groups: nil,
-                                                                     site: 'monitoring'
-                                                                   }).that_comes_before('Class[check_mk::service]') }
+        it { is_expected.to contain_class('check_mk::install').with(filestore: nil,
+                                                                    package: 'omd-0.56',
+                                                                    site: 'monitoring',
+                                                                    workspace: '/root/check_mk').that_comes_before('Class[check_mk::config]')
+        }
+        it { is_expected.to contain_class('check_mk::config').with(host_groups: nil,
+                                                                   site: 'monitoring').that_comes_before('Class[check_mk::service]')
+        }
         it { is_expected.to contain_class('check_mk::service') }
       end
     end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -33,10 +33,8 @@ describe 'check_mk::agent::mrpe', type: :define do
 
       it { is_expected.to contain_check_mk__agent__mrpe('checkname') }
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
-      it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with({
-                                                                                  target: '/etc/check-mk-agent/mrpe.cfg',
-                                                                                  content: /^checkname command\n$/
-                                                                                })
+      it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with(target: '/etc/check-mk-agent/mrpe.cfg',
+                                                                                content: /^checkname command\n$/)
       }
     end
   end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe 'check_mk::agent::mrpe', :type => :define do
+describe 'check_mk::agent::mrpe', type: :define do
   let :title do
     'checkname'
   end
@@ -12,7 +12,7 @@ describe 'check_mk::agent::mrpe', :type => :define do
 
     context 'with mandatory command' do
       let :params do
-        {:command => 'command'}
+        {command: 'command'}
       end
 
       it { is_expected.to compile.and_raise_error(%r{Creating mrpe\.cfg is unsupported for operatingsystem}) }
@@ -21,18 +21,18 @@ describe 'check_mk::agent::mrpe', :type => :define do
   context 'RedHat Linux' do
     let :facts do
       {
-          :operatingsystem => 'redhat',
+          operatingsystem: 'redhat',
       }
     end
     context 'with mandatory command' do
       let :params do
-        {:command => 'command'}
+        {command: 'command'}
       end
       it { should contain_check_mk__agent__mrpe('checkname') }
       it { should contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
       it { should contain_concat__fragment('checkname-mrpe-check').with({
-            :target  => '/etc/check-mk-agent/mrpe.cfg',
-            :content => /^checkname command\n$/,
+            target: '/etc/check-mk-agent/mrpe.cfg',
+            content: /^checkname command\n$/,
         })
       }
     end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -13,7 +13,7 @@ describe 'check_mk::agent::mrpe', type: :define do
 
     context 'with mandatory command' do
       let :params do
-        {command: 'command'}
+        { command: 'command' }
       end
 
       it { is_expected.to compile.and_raise_error(%r{Creating mrpe\.cfg is unsupported for operatingsystem}) }
@@ -28,7 +28,7 @@ describe 'check_mk::agent::mrpe', type: :define do
 
     context 'with mandatory command' do
       let :params do
-        {command: 'command'}
+        { command: 'command' }
       end
 
       it { is_expected.to contain_check_mk__agent__mrpe('checkname') }

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -21,7 +21,7 @@ describe 'check_mk::agent::mrpe', type: :define do
   context 'RedHat Linux' do
     let :facts do
       {
-          operatingsystem: 'redhat'
+        operatingsystem: 'redhat'
       }
     end
     context 'with mandatory command' do
@@ -31,9 +31,9 @@ describe 'check_mk::agent::mrpe', type: :define do
       it { is_expected.to contain_check_mk__agent__mrpe('checkname') }
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
       it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with({
-            target: '/etc/check-mk-agent/mrpe.cfg',
-            content: /^checkname command\n$/
-        })
+                                                                                  target: '/etc/check-mk-agent/mrpe.cfg',
+                                                                                  content: /^checkname command\n$/
+                                                                                })
       }
     end
   end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -35,7 +35,7 @@ describe 'check_mk::agent::mrpe', type: :define do
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
       it {
         is_expected.to contain_concat__fragment('checkname-mrpe-check').with(target: '/etc/check-mk-agent/mrpe.cfg',
-                                                                             content: /^checkname command\n$/)
+                                                                             content: %r{^checkname command\n$})
       }
     end
   end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -3,6 +3,7 @@ describe 'check_mk::agent::mrpe', type: :define do
   let :title do
     'checkname'
   end
+
   context 'Unsupported OS' do
     let :facts do
       {
@@ -24,10 +25,12 @@ describe 'check_mk::agent::mrpe', type: :define do
         operatingsystem: 'redhat'
       }
     end
+
     context 'with mandatory command' do
       let :params do
         {command: 'command'}
       end
+
       it { is_expected.to contain_check_mk__agent__mrpe('checkname') }
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
       it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with({

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -6,7 +6,7 @@ describe 'check_mk::agent::mrpe', type: :define do
   context 'Unsupported OS' do
     let :facts do
       {
-        operatingsystem: 'Solaris',
+        operatingsystem: 'Solaris'
       }
     end
 
@@ -21,7 +21,7 @@ describe 'check_mk::agent::mrpe', type: :define do
   context 'RedHat Linux' do
     let :facts do
       {
-          operatingsystem: 'redhat',
+          operatingsystem: 'redhat'
       }
     end
     context 'with mandatory command' do
@@ -32,7 +32,7 @@ describe 'check_mk::agent::mrpe', type: :define do
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
       it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with({
             target: '/etc/check-mk-agent/mrpe.cfg',
-            content: /^checkname command\n$/,
+            content: /^checkname command\n$/
         })
       }
     end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -28,9 +28,9 @@ describe 'check_mk::agent::mrpe', type: :define do
       let :params do
         {command: 'command'}
       end
-      it { should contain_check_mk__agent__mrpe('checkname') }
-      it { should contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
-      it { should contain_concat__fragment('checkname-mrpe-check').with({
+      it { is_expected.to contain_check_mk__agent__mrpe('checkname') }
+      it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
+      it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with({
             target: '/etc/check-mk-agent/mrpe.cfg',
             content: /^checkname command\n$/,
         })

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -33,8 +33,9 @@ describe 'check_mk::agent::mrpe', type: :define do
 
       it { is_expected.to contain_check_mk__agent__mrpe('checkname') }
       it { is_expected.to contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
-      it { is_expected.to contain_concat__fragment('checkname-mrpe-check').with(target: '/etc/check-mk-agent/mrpe.cfg',
-                                                                                content: /^checkname command\n$/)
+      it {
+        is_expected.to contain_concat__fragment('checkname-mrpe-check').with(target: '/etc/check-mk-agent/mrpe.cfg',
+                                                                             content: /^checkname command\n$/)
       }
     end
   end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -7,8 +7,8 @@ describe 'check_mk::host', type: :define do
     let :params do
       {target: 'target'}
     end
-    it { should contain_check_mk__host('host') }
-    it { should contain_concat__fragment('check_mk-host').with({
+    it { is_expected.to contain_check_mk__host('host') }
+    it { is_expected.to contain_concat__fragment('check_mk-host').with({
           target: 'target',
           content: /^  'host',\n$/,
           order: 11,
@@ -22,8 +22,8 @@ describe 'check_mk::host', type: :define do
           host_tags: ['tag1', 'tag2'],
       }
     end
-    it { should contain_check_mk__host('host') }
-    it { should contain_concat__fragment('check_mk-host').with({
+    it { is_expected.to contain_check_mk__host('host') }
+    it { is_expected.to contain_concat__fragment('check_mk-host').with({
           target: 'target',
           content: /^  'host|tag1|tag2',\n$/,
           order: 11,

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -9,25 +9,25 @@ describe 'check_mk::host', type: :define do
     end
     it { is_expected.to contain_check_mk__host('host') }
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
-          target: 'target',
-          content: /^  'host',\n$/,
-          order: 11
-      })
+                                                                         target: 'target',
+                                                                         content: /^  'host',\n$/,
+                                                                         order: 11
+                                                                       })
     }
   end
   context 'with custom host_tags' do
     let :params do
       {
-          target: 'target',
-          host_tags: ['tag1', 'tag2']
+        target: 'target',
+        host_tags: ['tag1', 'tag2']
       }
     end
     it { is_expected.to contain_check_mk__host('host') }
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
-          target: 'target',
-          content: /^  'host|tag1|tag2',\n$/,
-          order: 11
-      })
+                                                                         target: 'target',
+                                                                         content: /^  'host|tag1|tag2',\n$/,
+                                                                         order: 11
+                                                                       })
     }
   end
 end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -6,7 +6,7 @@ describe 'check_mk::host', type: :define do
 
   context 'with empty host_tags array' do
     let :params do
-      {target: 'target'}
+      { target: 'target' }
     end
 
     it { is_expected.to contain_check_mk__host('host') }

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -10,11 +10,9 @@ describe 'check_mk::host', type: :define do
     end
 
     it { is_expected.to contain_check_mk__host('host') }
-    it { is_expected.to contain_concat__fragment('check_mk-host').with({
-                                                                         target: 'target',
-                                                                         content: /^  'host',\n$/,
-                                                                         order: 11
-                                                                       })
+    it { is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
+                                                                       content: /^  'host',\n$/,
+                                                                       order: 11)
     }
   end
   context 'with custom host_tags' do
@@ -26,11 +24,9 @@ describe 'check_mk::host', type: :define do
     end
 
     it { is_expected.to contain_check_mk__host('host') }
-    it { is_expected.to contain_concat__fragment('check_mk-host').with({
-                                                                         target: 'target',
-                                                                         content: /^  'host|tag1|tag2',\n$/,
-                                                                         order: 11
-                                                                       })
+    it { is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
+                                                                       content: /^  'host|tag1|tag2',\n$/,
+                                                                       order: 11)
     }
   end
 end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -3,10 +3,12 @@ describe 'check_mk::host', type: :define do
   let :title do
     'host'
   end
+
   context 'with empty host_tags array' do
     let :params do
       {target: 'target'}
     end
+
     it { is_expected.to contain_check_mk__host('host') }
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
                                                                          target: 'target',
@@ -22,6 +24,7 @@ describe 'check_mk::host', type: :define do
         host_tags: ['tag1', 'tag2']
       }
     end
+
     it { is_expected.to contain_check_mk__host('host') }
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
                                                                          target: 'target',

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
-describe 'check_mk::host', :type => :define do
+describe 'check_mk::host', type: :define do
   let :title do
     'host'
   end
   context 'with empty host_tags array' do
     let :params do
-      {:target => 'target'}
+      {target: 'target'}
     end
     it { should contain_check_mk__host('host') }
     it { should contain_concat__fragment('check_mk-host').with({
-          :target  => 'target',
-          :content => /^  'host',\n$/,
-          :order   => 11,
+          target: 'target',
+          content: /^  'host',\n$/,
+          order: 11,
       })
     }
   end
   context 'with custom host_tags' do
     let :params do
       {
-          :target => 'target',
-          :host_tags => ['tag1', 'tag2'],
+          target: 'target',
+          host_tags: ['tag1', 'tag2'],
       }
     end
     it { should contain_check_mk__host('host') }
     it { should contain_concat__fragment('check_mk-host').with({
-          :target  => 'target',
-          :content => /^  'host|tag1|tag2',\n$/,
-          :order   => 11,
+          target: 'target',
+          content: /^  'host|tag1|tag2',\n$/,
+          order: 11,
       })
     }
   end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -12,7 +12,7 @@ describe 'check_mk::host', type: :define do
     it { is_expected.to contain_check_mk__host('host') }
     it {
       is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
-                                                                    content: /^  'host',\n$/,
+                                                                    content: %r{^  'host',\n$},
                                                                     order: 11)
     }
   end
@@ -27,7 +27,7 @@ describe 'check_mk::host', type: :define do
     it { is_expected.to contain_check_mk__host('host') }
     it {
       is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
-                                                                    content: /^  'host|tag1|tag2',\n$/,
+                                                                    content: %r{^  'host|tag1|tag2',\n$},
                                                                     order: 11)
     }
   end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -10,9 +10,10 @@ describe 'check_mk::host', type: :define do
     end
 
     it { is_expected.to contain_check_mk__host('host') }
-    it { is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
-                                                                       content: /^  'host',\n$/,
-                                                                       order: 11)
+    it {
+      is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
+                                                                    content: /^  'host',\n$/,
+                                                                    order: 11)
     }
   end
   context 'with custom host_tags' do
@@ -24,9 +25,10 @@ describe 'check_mk::host', type: :define do
     end
 
     it { is_expected.to contain_check_mk__host('host') }
-    it { is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
-                                                                       content: /^  'host|tag1|tag2',\n$/,
-                                                                       order: 11)
+    it {
+      is_expected.to contain_concat__fragment('check_mk-host').with(target: 'target',
+                                                                    content: /^  'host|tag1|tag2',\n$/,
+                                                                    order: 11)
     }
   end
 end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -11,7 +11,7 @@ describe 'check_mk::host', type: :define do
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
           target: 'target',
           content: /^  'host',\n$/,
-          order: 11,
+          order: 11
       })
     }
   end
@@ -19,14 +19,14 @@ describe 'check_mk::host', type: :define do
     let :params do
       {
           target: 'target',
-          host_tags: ['tag1', 'tag2'],
+          host_tags: ['tag1', 'tag2']
       }
     end
     it { is_expected.to contain_check_mk__host('host') }
     it { is_expected.to contain_concat__fragment('check_mk-host').with({
           target: 'target',
           content: /^  'host|tag1|tag2',\n$/,
-          order: 11,
+          order: 11
       })
     }
   end

--- a/spec/defines/check_mk_host_spec.rb
+++ b/spec/defines/check_mk_host_spec.rb
@@ -20,7 +20,7 @@ describe 'check_mk::host', type: :define do
     let :params do
       {
         target: 'target',
-        host_tags: ['tag1', 'tag2']
+        host_tags: %w[tag1 tag2]
       }
     end
 

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -26,6 +26,7 @@ describe 'check_mk::hostgroup' do
             target: 'target'
           }
         end
+
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
                                                                                                  target: 'target',
@@ -65,6 +66,7 @@ EOS
             target: '/target'
           }
         end
+
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
                                                                                                                    target: '/target',

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -28,9 +28,10 @@ describe 'check_mk::hostgroup' do
         end
 
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
-        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with(target: 'target',
-                                                                                               content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-                                                                                               order: 21)
+        it {
+          is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with(target: 'target',
+                                                                                            content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                            order: 21)
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -38,8 +39,9 @@ define hostgroup {
   alias TEST_DESCRIPTION
 }
 EOS
-        it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with(ensure: 'file',
-                                                                         content: expected_file_content)
+        it {
+          is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with(ensure: 'file',
+                                                                      content: expected_file_content)
         }
       end
 
@@ -64,9 +66,10 @@ EOS
         end
 
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
-        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with(target: '/target',
-                                                                                                                 content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-                                                                                                                 order: 21)
+        it {
+          is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with(target: '/target',
+                                                                                                              content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                                              order: 21)
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -74,8 +77,9 @@ define hostgroup {
   alias TEST HOUSTGROUP_WITH_UNDERSCORES
 }
 EOS
-        it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with(ensure: 'file',
-                                                                                           content: expected_file_content)
+        it {
+          is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with(ensure: 'file',
+                                                                                        content: expected_file_content)
         }
       end
     end

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -14,10 +14,10 @@ describe 'check_mk::hostgroup' do
           'TEST_HOSTGROUP' => {
             'host_tags' => [
               'tag1',
-              'tag2',
+              'tag2'
             ],
-            'description' => 'TEST_DESCRIPTION',
-          },
+            'description' => 'TEST_DESCRIPTION'
+          }
         }
         let :params do
           {
@@ -30,7 +30,7 @@ describe 'check_mk::hostgroup' do
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
           target: 'target',
           content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          order: 21,
+          order: 21
         })
         }
         expected_file_content = <<EOS
@@ -41,7 +41,7 @@ define hostgroup {
 EOS
         it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with({
           ensure: 'file',
-          content: expected_file_content,
+          content: expected_file_content
         })
         }
       end
@@ -54,9 +54,9 @@ EOS
           'TEST_HOUSTGROUP_WITH_UNDERSCORES' => {
             'host_tags' => [
               'tag1',
-              'tag2',
-            ],
-          },
+              'tag2'
+            ]
+          }
         }
         let :params do
           {
@@ -69,7 +69,7 @@ EOS
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
           target: '/target',
           content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          order: 21,
+          order: 21
         })
         }
         expected_file_content = <<EOS
@@ -80,7 +80,7 @@ define hostgroup {
 EOS
         it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
           ensure: 'file',
-          content: expected_file_content,
+          content: expected_file_content
         })
         }
       end

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -28,10 +28,10 @@ describe 'check_mk::hostgroup' do
         end
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
-          target: 'target',
-          content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          order: 21
-        })
+                                                                                                 target: 'target',
+                                                                                                 content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                                 order: 21
+                                                                                               })
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -40,9 +40,9 @@ define hostgroup {
 }
 EOS
         it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with({
-          ensure: 'file',
-          content: expected_file_content
-        })
+                                                                           ensure: 'file',
+                                                                           content: expected_file_content
+                                                                         })
         }
       end
 
@@ -67,10 +67,10 @@ EOS
         end
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
         it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
-          target: '/target',
-          content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          order: 21
-        })
+                                                                                                                   target: '/target',
+                                                                                                                   content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                                                   order: 21
+                                                                                                                 })
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -79,9 +79,9 @@ define hostgroup {
 }
 EOS
         it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
-          ensure: 'file',
-          content: expected_file_content
-        })
+                                                                                             ensure: 'file',
+                                                                                             content: expected_file_content
+                                                                                           })
         }
       end
     end

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -28,11 +28,9 @@ describe 'check_mk::hostgroup' do
         end
 
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
-        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
-                                                                                                 target: 'target',
-                                                                                                 content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-                                                                                                 order: 21
-                                                                                               })
+        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with(target: 'target',
+                                                                                               content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                               order: 21)
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -40,10 +38,8 @@ define hostgroup {
   alias TEST_DESCRIPTION
 }
 EOS
-        it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with({
-                                                                           ensure: 'file',
-                                                                           content: expected_file_content
-                                                                         })
+        it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with(ensure: 'file',
+                                                                         content: expected_file_content)
         }
       end
 
@@ -68,11 +64,9 @@ EOS
         end
 
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
-        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
-                                                                                                                   target: '/target',
-                                                                                                                   content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-                                                                                                                   order: 21
-                                                                                                                 })
+        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with(target: '/target',
+                                                                                                                 content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                                                 order: 21)
         }
         expected_file_content = <<EOS
 define hostgroup {
@@ -80,10 +74,8 @@ define hostgroup {
   alias TEST HOUSTGROUP_WITH_UNDERSCORES
 }
 EOS
-        it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
-                                                                                             ensure: 'file',
-                                                                                             content: expected_file_content
-                                                                                           })
+        it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with(ensure: 'file',
+                                                                                           content: expected_file_content)
         }
       end
     end

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -30,7 +30,7 @@ describe 'check_mk::hostgroup' do
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
         it {
           is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with(target: 'target',
-                                                                                            content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                            content: %r{^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$},
                                                                                             order: 21)
         }
         expected_file_content = <<EOS
@@ -68,7 +68,7 @@ EOS
         it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
         it {
           is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with(target: '/target',
-                                                                                                              content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+                                                                                                              content: %r{^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$},
                                                                                                               order: 21)
         }
         expected_file_content = <<EOS

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -21,16 +21,16 @@ describe 'check_mk::hostgroup' do
         }
         let :params do
           {
-            :dir        => '/dir',
-            :hostgroups => hostgroups,
-            :target     => 'target'
+            dir: '/dir',
+            hostgroups: hostgroups,
+            target: 'target'
           }
         end
         it { should contain_check_mk__hostgroup('TEST_HOSTGROUP') }
         it { should contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
-          :target  => 'target',
-          :content => /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          :order   => 21,
+          target: 'target',
+          content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+          order: 21,
         })
         }
         expected_file_content = <<EOS
@@ -40,8 +40,8 @@ define hostgroup {
 }
 EOS
         it { should contain_file('/dir/TEST_HOSTGROUP.cfg').with({
-          :ensure => 'file',
-          :content => expected_file_content,
+          ensure: 'file',
+          content: expected_file_content,
         })
         }
       end
@@ -60,16 +60,16 @@ EOS
         }
         let :params do
           {
-            :dir        => '/dir',
-            :hostgroups => hostgroups,
-            :target     => '/target'
+            dir: '/dir',
+            hostgroups: hostgroups,
+            target: '/target'
           }
         end
         it { should contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
         it { should contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
-          :target  => '/target',
-          :content => /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
-          :order   => 21,
+          target: '/target',
+          content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
+          order: 21,
         })
         }
         expected_file_content = <<EOS
@@ -79,8 +79,8 @@ define hostgroup {
 }
 EOS
         it { should contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
-          :ensure  => 'file',
-          :content => expected_file_content,
+          ensure: 'file',
+          content: expected_file_content,
         })
         }
       end

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -26,8 +26,8 @@ describe 'check_mk::hostgroup' do
             target: 'target'
           }
         end
-        it { should contain_check_mk__hostgroup('TEST_HOSTGROUP') }
-        it { should contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
+        it { is_expected.to contain_check_mk__hostgroup('TEST_HOSTGROUP') }
+        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOSTGROUP').with({
           target: 'target',
           content: /^  \( 'TEST_HOSTGROUP', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
           order: 21,
@@ -39,7 +39,7 @@ define hostgroup {
   alias TEST_DESCRIPTION
 }
 EOS
-        it { should contain_file('/dir/TEST_HOSTGROUP.cfg').with({
+        it { is_expected.to contain_file('/dir/TEST_HOSTGROUP.cfg').with({
           ensure: 'file',
           content: expected_file_content,
         })
@@ -65,8 +65,8 @@ EOS
             target: '/target'
           }
         end
-        it { should contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
-        it { should contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
+        it { is_expected.to contain_check_mk__hostgroup('TEST_HOUSTGROUP_WITH_UNDERSCORES') }
+        it { is_expected.to contain_concat__fragment('check_mk-hostgroup-TEST_HOUSTGROUP_WITH_UNDERSCORES').with({
           target: '/target',
           content: /^  \( 'TEST_HOUSTGROUP_WITH_UNDERSCORES', \[ 'tag1', 'tag2' \], ALL_HOSTS \),\n$/,
           order: 21,
@@ -78,7 +78,7 @@ define hostgroup {
   alias TEST HOUSTGROUP_WITH_UNDERSCORES
 }
 EOS
-        it { should contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
+        it { is_expected.to contain_file('/dir/TEST_HOUSTGROUP_WITH_UNDERSCORES.cfg').with({
           ensure: 'file',
           content: expected_file_content,
         })

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -7,9 +7,6 @@ describe 'check_mk::hostgroup' do
       end
 
       context 'with hostgroups, host_tags and description' do
-        let :title do
-          'TEST_HOSTGROUP'
-        end
         hostgroups = {
           'TEST_HOSTGROUP' => {
             'host_tags' => %w[
@@ -19,6 +16,9 @@ describe 'check_mk::hostgroup' do
             'description' => 'TEST_DESCRIPTION'
           }
         }
+        let :title do
+          'TEST_HOSTGROUP'
+        end
         let :params do
           {
             dir: '/dir',
@@ -46,9 +46,6 @@ EOS
       end
 
       context 'with hostgroups without description' do
-        let :title do
-          'TEST_HOUSTGROUP_WITH_UNDERSCORES'
-        end
         hostgroups = {
           'TEST_HOUSTGROUP_WITH_UNDERSCORES' => {
             'host_tags' => %w[
@@ -57,6 +54,9 @@ EOS
             ]
           }
         }
+        let :title do
+          'TEST_HOUSTGROUP_WITH_UNDERSCORES'
+        end
         let :params do
           {
             dir: '/dir',

--- a/spec/defines/check_mk_hostgroup_spec.rb
+++ b/spec/defines/check_mk_hostgroup_spec.rb
@@ -12,9 +12,9 @@ describe 'check_mk::hostgroup' do
         end
         hostgroups = {
           'TEST_HOSTGROUP' => {
-            'host_tags' => [
-              'tag1',
-              'tag2'
+            'host_tags' => %w[
+              tag1
+              tag2
             ],
             'description' => 'TEST_DESCRIPTION'
           }
@@ -51,9 +51,9 @@ EOS
         end
         hostgroups = {
           'TEST_HOUSTGROUP_WITH_UNDERSCORES' => {
-            'host_tags' => [
-              'tag1',
-              'tag2'
+            'host_tags' => %w[
+              tag1
+              tag2
             ]
           }
         }


### PR DESCRIPTION
Mostly autofixes split by cop.  Manual fixes for `RSpec/ScatteredLet`, `RSpec/RepeatedExample` and some instances of `Style/RegexpLiteral`