### PR TITLE
Make name of checkmk service variable

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -21,6 +21,7 @@ class check_mk::agent (
   Optional[Array] $host_tags = undef,
   Stdlib::Absolutepath $workspace = '/root/check_mk',
   Optional[String] $package = 'check-mk-agent',
+  Optional[String[1]] $service_name = 'check_mk',
   Hash $mrpe_checks = {},
   Optional[String[1]] $encryption_secret = undef,
   Boolean $use_xinetd = !fact('systemd'),

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -14,6 +14,7 @@ class check_mk::agent::config (
   String[1]                  $user                 = $check_mk::agent::user,
   String[1]                  $group                = $check_mk::agent::group,
   Stdlib::Absolutepath       $config_dir           = $check_mk::agent::config_dir,
+  String[1]                  $service_name         = $check_mk::agent::service_name,
 ) inherits check_mk::agent {
   if $use_xinetd == false and fact('systemd') == false {
     fail('Your system doesn\'t appear to support systemd, you must use xinetd instead')
@@ -85,7 +86,7 @@ class check_mk::agent::config (
 
     systemd::dropin_file { 'check_mk socket overrides':
       filename => 'puppet.conf',
-      unit     => 'check_mk.socket',
+      unit     => "${service_name}.socket",
       content  => epp(
         'check_mk/agent/check_mk.socket-drop-in.epp',
         {
@@ -96,7 +97,7 @@ class check_mk::agent::config (
     }
     systemd::dropin_file { 'check_mk unit overrides':
       filename => 'puppet.conf',
-      unit     => 'check_mk@.service',
+      unit     => "${service_name}@.service",
       content  => epp(
         'check_mk/agent/check_mk.service-drop-in.epp',
         {

--- a/manifests/agent/service.pp
+++ b/manifests/agent/service.pp
@@ -6,13 +6,14 @@
 #
 class check_mk::agent::service (
   Boolean $use_xinetd = $check_mk::agent::use_xinetd,
+  String $service_name = $check_mk::agent::service_name,
 )
 {
   if $use_xinetd {
     ensure_packages(['xinetd'])
     Package['xinetd'] ~> Service['xinetd']
 
-    service { 'check_mk.socket':
+    service { "${service_name}.socket":
       ensure => 'stopped',
       enable => false,
       notify => Service['xinetd'],
@@ -40,7 +41,7 @@ class check_mk::agent::service (
         restart    => 'kill -USR2 `pidof xinetd` && sleep 1',
       }
     }
-    service { 'check_mk.socket':
+    service { "${service_name}.socket":
       ensure  => 'running',
       enable  => true,
       require => Service['xinetd'],

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -306,6 +306,26 @@ describe 'check_mk::agent::config' do
                 end
               end
             end
+
+            context 'with non-standard unit name' do
+              let(:params) do
+                {
+                  service_name: 'custom-check-mk-agent'
+                }
+              end
+
+              it do
+                is_expected.to contain_systemd__dropin_file('check_mk socket overrides').with(
+                  unit: 'custom-check-mk-agent.socket'
+                )
+              end
+
+              it do
+                is_expected.to contain_systemd__dropin_file('check_mk unit overrides').with(
+                  unit: 'custom-check-mk-agent@.service'
+                )
+              end
+            end
           else
             it { is_expected.to compile.and_raise_error(%r{Your system doesn't appear to support systemd, you must use xinetd instead}) }
           end

--- a/spec/classes/check_mk_agent_service_spec.rb
+++ b/spec/classes/check_mk_agent_service_spec.rb
@@ -6,7 +6,7 @@ describe 'check_mk::agent::service' do
       let(:facts) { facts }
 
       context 'when using xinetd' do
-        let(:params) { { use_xinetd: true } }
+        let(:params) { { use_xinetd: true, service_name: 'check_mk' } }
 
         it { is_expected.to contain_package('xinetd') }
         it { is_expected.to contain_service('check_mk.socket').with_ensure('stopped').with_enable(false) }
@@ -20,7 +20,7 @@ describe 'check_mk::agent::service' do
         }
       end
       context 'when using systemd' do
-        let(:params) { { use_xinetd: false } }
+        let(:params) { { use_xinetd: false, service_name: 'check_mk' } }
 
         it { is_expected.not_to contain_package('xinetd') }
         it {
@@ -35,6 +35,16 @@ describe 'check_mk::agent::service' do
             'enable' => true
           ).that_requires('Service[xinetd]')
         }
+
+        context 'with non-standard service name' do
+          let(:params) do
+            super().merge(service_name: 'custom-check-mk-agent')
+          end
+
+          it do
+            is_expected.to contain_service('custom-check-mk-agent.socket')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Some packages from the bakery might use a different name and will therefore not work with the defaults.