### PR TITLE
Add `package_ensure` attribute to agent.pp

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -5,6 +5,7 @@
 # @param host_tags Tags that needs to be added to the node if resource export is enabled.
 # @param workspace Temp folder where the installation file will be placed.
 # @param package The package name to be installed.
+# @param package_ensure The `ensure` value to use when installing the agent from a package repository, (when `filestore` is not set). This option can be used to install a specific package version.
 # @param mrpe_checks A hash containing mrpe command that will be passed to the mrpe defined type.
 # @param encryption_secret A secret that will be used to encrypt communication with the master.
 # @param config_dir The config directory for the agent.
@@ -21,6 +22,7 @@ class check_mk::agent (
   Optional[Array] $host_tags = undef,
   Stdlib::Absolutepath $workspace = '/root/check_mk',
   Optional[String] $package = 'check-mk-agent',
+  String[1] $package_ensure = 'present',
   Optional[String[1]] $service_name = 'check_mk',
   Hash $mrpe_checks = {},
   Optional[String[1]] $encryption_secret = undef,

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -4,9 +4,10 @@
 # @api private
 #
 class check_mk::agent::install (
-  $filestore = $check_mk::agent::filestore,
-  $workspace = $check_mk::agent::workspace,
-  $package   = $check_mk::agent::package,
+  $filestore      = $check_mk::agent::filestore,
+  $workspace      = $check_mk::agent::workspace,
+  $package        = $check_mk::agent::package,
+  $package_ensure = $check_mk::agent::package_ensure,
 ) inherits check_mk::agent {
   if $filestore {
     if ! defined(File[$workspace]) {
@@ -44,7 +45,7 @@ class check_mk::agent::install (
     }
   } else {
     package { 'check_mk-agent':
-      ensure => present,
+      ensure => $package_ensure,
       name   => $package,
     }
   }

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -32,6 +32,17 @@ describe 'check_mk::agent::install' do
       }
     end
 
+    context "with custom package_ensure on #{os}" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          package_ensure: '1.2.8p27-1'
+        }
+      end
+
+      it { is_expected.to contain_package('check_mk-agent').with_ensure('1.2.8p27-1') }
+    end
+
     context "with filestore on #{os}" do
       let(:facts) { os_facts }
       let(:params) do


### PR DESCRIPTION
Needed to install a specific package version.  In my case I need to
install check-mk-agent-1.2.8p27-1 from a custom repo and not the later
1.4.x version from EPEL.