### PR TITLE
Ignore failed agent starts

### DIFF
--- a/templates/agent/check_mk.service-drop-in.epp
+++ b/templates/agent/check_mk.service-drop-in.epp
@@ -5,6 +5,9 @@
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 [Service]
+# Reset command list.
+# See https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
+# "If the empty string is assigned to this option, the list of commands to start is reset, prior assignments of this option will have no effect".
 ExecStart=
 ExecStart=<%= $server %>
 User=<%= $user %>

--- a/templates/agent/check_mk.service-drop-in.epp
+++ b/templates/agent/check_mk.service-drop-in.epp
@@ -9,6 +9,8 @@
 # See https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=
 # "If the empty string is assigned to this option, the list of commands to start is reset, prior assignments of this option will have no effect".
 ExecStart=
-ExecStart=<%= $server %>
+# "-" path prefix makes systemd record the exit code,
+# but the unit is not set to failed.
+ExecStart=-<%= $server %>
 User=<%= $user %>
 Group=<%= $group %>


### PR DESCRIPTION
See also:
* https://checkmk.com/de/werk/10710
* https://github.com/tribe29/checkmk/commit/d342d63a8d89c42d4c8b003403b6681d152952cf

#### Pull Request (PR) description
This PR prepends a "-" to the agent executable name in order to make it ignore agent failures without failing the unit.
It also adds some comments, in order to make the code more readable.

#### This Pull Request (PR) fixes the following issues
I did not create an issue accompanying this PR.