### PR TITLE
Rename site parameter to monitoring_site

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ htpasswd -i ~/etc/passwd cmkadmin
 The following example changes the default site name from 'monitoring' to 'differentsitename'
 ```puppet
 class { 'check_mk':
-  site => 'differentsitename',
+  monitoring_site => 'differentsitename',
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,16 +5,16 @@
 #
 
 class check_mk::config (
-  String $site,
+  String $monitoring_site,
   Optional[Hash] $host_groups = undef,
   Optional[Array] $all_hosts_static = undef,
 ) {
-  $etc_dir = "/omd/sites/${site}/etc"
-  $bin_dir = "/omd/sites/${site}/bin"
+  $etc_dir = "/omd/sites/${monitoring_site}/etc"
+  $bin_dir = "/omd/sites/${monitoring_site}/bin"
   file { "${etc_dir}/nagios/local":
     ensure => directory,
-    owner  => $site,
-    group  => $site,
+    owner  => $monitoring_site,
+    group  => $monitoring_site,
   }
 
   file_line { 'nagios-add-check_mk-cfg_dir':
@@ -25,8 +25,8 @@ class check_mk::config (
   }
 
   concat { "${etc_dir}/check_mk/main.mk":
-    owner => $site,
-    group => $site,
+    owner => $monitoring_site,
+    group => $monitoring_site,
     mode  => '0644',
   }
 
@@ -42,7 +42,7 @@ class check_mk::config (
     content => template('check_mk/all_hosts_static.erb'),
   }
 
-  # # local list of hosts is in /omd/sites/${site}/etc/check_mk/all_hosts_static and is appended
+  # # local list of hosts is in /omd/sites/${monitoring_site}/etc/check_mk/all_hosts_static and is appended
   concat::fragment { 'all-hosts-static':
     source => "${etc_dir}/check_mk/all_hosts_static",
     target => "${etc_dir}/check_mk/main.mk",
@@ -84,7 +84,7 @@ class check_mk::config (
     }
   }
 
-  # # local config is in /omd/sites/${site}/etc/check_mk/main.mk.local and is appended
+  # # local config is in /omd/sites/${monitoring_site}/etc/check_mk/main.mk.local and is appended
   file { "${etc_dir}/check_mk/main.mk.local":
     ensure => file,
     owner  => 'root',
@@ -99,7 +99,7 @@ class check_mk::config (
   }
 
   exec { 'check_mk-reload':
-    command     => "/bin/su -l -c '${bin_dir}/check_mk --reload' ${site}",
+    command     => "/bin/su -l -c '${bin_dir}/check_mk --reload' ${monitoring_site}",
     refreshonly => true,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,19 +4,19 @@ class check_mk (
   $host_groups      = $check_mk::params::host_groups,
   $httpd_service    = $check_mk::params::httpd_service,
   $package          = $check_mk::params::package,
-  $site             = $check_mk::params::site,
+  $monitoring_site  = $check_mk::params::monitoring_site,
   $workspace        = $check_mk::params::workspace,
 ) inherits check_mk::params {
   class { 'check_mk::install':
-    filestore => $filestore,
-    package   => $package,
-    site      => $site,
-    workspace => $workspace,
+    filestore       => $filestore,
+    package         => $package,
+    monitoring_site => $monitoring_site,
+    workspace       => $workspace,
   }
   class { 'check_mk::config':
-    host_groups => $host_groups,
-    site        => $site,
-    require     => Class['check_mk::install'],
+    host_groups     => $host_groups,
+    monitoring_site => $monitoring_site,
+    require         => Class['check_mk::install'],
   }
   class { 'check_mk::service':
     checkmk_service => $checkmk_service,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@
 #
 
 class check_mk::install (
-  String $site,
+  String $monitoring_site,
   Stdlib::Absolutepath $workspace,
   Optional[String] $filestore = undef,
   Optional[Pattern[/^(check-mk-(\w*))(-|_)(\d*\.\d*\.\d*p\d*).+\.(\w+)$/]] $package = undef,
@@ -60,9 +60,9 @@ class check_mk::install (
       before => Exec['omd-create-site'],
     }
   }
-  $etc_dir = "/omd/sites/${site}/etc"
+  $etc_dir = "/omd/sites/${monitoring_site}/etc"
   exec { 'omd-create-site':
-    command => "/usr/bin/omd create ${site}",
+    command => "/usr/bin/omd create ${monitoring_site}",
     creates => $etc_dir,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class check_mk::params {
   $package = 'check-mk-raw-1.5.0p7-el7-38.x86_64.rpm'
   $filestore = undef
   $host_groups= undef
-  $site = 'monitoring'
+  $monitoring_site = 'monitoring'
   $workspace = '/root/check_mk'
 
   # OS specific variables

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,15 +3,15 @@ require 'spec_helper_acceptance'
 describe 'check_mk class' do
   packagename = case fact('os.family')
                 when 'Debian'
-                  'check-mk-raw-1.5.0p15_0.' + fact('os.distro.codename') + '_amd64.deb'
+                  'check-mk-raw-2.0.0p1_0.' + fact('os.distro.codename') + '_amd64.deb'
                 when 'RedHat'
-                  'check-mk-raw-1.5.0p15-el' + fact('os.release.major') + '-38.x86_64.rpm'
+                  'check-mk-raw-2.0.0p1-el' + fact('os.release.major') + '-38.x86_64.rpm'
                 end
   packagename_agent = case fact('os.family')
                       when 'Debian'
-                        'check-mk-agent_1.5.0p15-1_all.deb'
+                        'check-mk-agent_2.0.0p1-1_all.deb'
                       when 'RedHat'
-                        'check-mk-agent-1.5.0p15-1.noarch.rpm'
+                        'check-mk-agent-2.0.0p1-1.noarch.rpm'
                       end
 
   context 'minimal parameters' do
@@ -19,7 +19,7 @@ describe 'check_mk class' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
       class { 'check_mk':
-        filestore => 'https://mathias-kettner.de/support/1.5.0p15/',
+        filestore => 'https://download.checkmk.com/checkmk/2.0.0p1/',
         package   => '#{packagename}',
       }
       EOS

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -65,9 +65,10 @@ describe 'check_mk::agent::config' do
         it {
           is_expected.to contain_file('/etc/check_mk/encryption.cfg').with(
             'ensure'  => 'file',
-            'mode'    => '0600',
-            'content' => %r{PASSPHRASE=SECRET\n}
+            'mode'    => '0600'
           )
+          content = catalogue.resource('file', '/etc/check_mk/encryption.cfg').parameters[:content]
+          expect(content).to include("PASSPHRASE=SECRET\n")
         }
       end
 

--- a/spec/classes/check_mk_config_spec.rb
+++ b/spec/classes/check_mk_config_spec.rb
@@ -4,7 +4,7 @@ describe 'check_mk::config' do
   on_supported_os.each do |os, os_facts|
     context "with site set on #{os}" do
       let(:facts) { os_facts }
-      let(:params) { { site: 'TEST_SITE' } }
+      let(:params) { { monitoring_site: 'TEST_SITE' } }
 
       it {
         is_expected.to compile
@@ -72,7 +72,7 @@ describe 'check_mk::config' do
       let(:facts) { os_facts }
       let(:params) do
         {
-          site: 'TEST_SITE',
+          monitoring_site: 'TEST_SITE',
           host_groups: {
             group1: {
               host_tags: []

--- a/spec/classes/check_mk_install_spec.rb
+++ b/spec/classes/check_mk_install_spec.rb
@@ -8,7 +8,7 @@ describe 'check_mk::install' do
         {
           filestore: '/filestore/',
           package: 'check-mk-raw-1.5.0p7_0.stretch_amd64.deb',
-          site: 'site',
+          monitoring_site: 'site',
           workspace: '/workspace'
         }
       end
@@ -40,7 +40,7 @@ describe 'check_mk::install' do
         {
           filestore: '/filestore/',
           package: 'check-mk-raw-1.5.0p7-el7-38.x86_64.rpm',
-          site: 'site',
+          monitoring_site: 'site',
           workspace: '/workspace'
         }
       end

--- a/spec/classes/check_mk_spec.rb
+++ b/spec/classes/check_mk_spec.rb
@@ -11,12 +11,12 @@ describe 'check_mk' do
         it {
           is_expected.to contain_class('check_mk::install').with(filestore: nil,
                                                                  package: 'check-mk-raw-1.5.0p7-el7-38.x86_64.rpm',
-                                                                 site: 'monitoring',
+                                                                 monitoring_site: 'monitoring',
                                                                  workspace: '/root/check_mk').that_comes_before('Class[check_mk::config]')
         }
         it {
           is_expected.to contain_class('check_mk::config').with(host_groups: nil,
-                                                                site: 'monitoring').that_comes_before('Class[check_mk::service]')
+                                                                monitoring_site: 'monitoring').that_comes_before('Class[check_mk::service]')
         }
         it { is_expected.to contain_class('check_mk::service') }
       end


### PR DESCRIPTION

#### Pull Request (PR) description
Since “site” is a protected keyword, it may not be used as a parameter name. I renamed it to “monitoring_site”.

#### This Pull Request (PR) fixes the following issues
Fixes #41 